### PR TITLE
Fix Member/Web window rendering the OS desktop instead of the Fresh app

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -784,19 +784,72 @@ export async function legacyHandler(req: Request): Promise<Response> {
 type FetchFn = (req: Request) => Response | Promise<Response>;
 
 let memberFetch: FetchFn | null = null;
+let memberLoadError: string | null = null;
 try {
   const mod = await import("./member/_fresh/server.js");
   memberFetch = (mod.default as { fetch: FetchFn }).fetch;
 } catch (err) {
+  memberLoadError = err instanceof Error ? err.message : String(err);
   console.warn(
     "[thirsty-os] /member is unavailable — run `deno task member:build` to build the Fresh member app.",
-    err instanceof Error ? err.message : err,
+    memberLoadError,
   );
 }
 
 function memberOwnsPath(p: string): boolean {
   return p === "/member" || p.startsWith("/member/") ||
     p.startsWith("/assets/") || p === "/logo.svg" || p === "/lp-logo.png";
+}
+
+// The Fresh member app failed to load (its build output, member/_fresh, wasn't
+// present at startup — it's git-ignored and produced by `deno task build`).
+// Serve a clear notice for the member routes instead of letting them fall
+// through to legacyHandler, which would render the entire Thirsty OS desktop
+// shell inside the member window (the "Member/Web opens Finder" bug).
+function renderMemberUnavailable(): Response {
+  const headers: Record<string, string> = {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  };
+  if (memberLoadError) {
+    headers["x-member-load-error"] = memberLoadError.slice(0, 200);
+  }
+  const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>Member app not built</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0; min-height: 100vh; display: grid; place-items: center;
+        background: #0b0d11; color: #e8eaed; padding: 2rem;
+        font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      .card {
+        max-width: 32rem; text-align: center; background: #14181f;
+        border: 1px solid #232a35; border-radius: 16px; padding: 2rem 1.75rem;
+      }
+      h1 { font-size: 1.15rem; margin: 0 0 .65rem; }
+      p { margin: .5rem 0; color: #aab3c0; }
+      code {
+        background: #0b0d11; border: 1px solid #232a35; border-radius: 6px;
+        padding: .15rem .4rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: .9em; color: #e8eaed;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Member app isn't built yet</h1>
+      <p>The Fresh member dashboard hasn't been built for this deployment.</p>
+      <p>Run <code>deno task build</code> (which runs <code>deno task member:build</code>)
+         before serving, or set it as the deployment's build command.</p>
+    </div>
+  </body>
+</html>`;
+  return new Response(html, { status: 503, headers });
 }
 
 Deno.serve({ port: Number(Deno.env.get("PORT")) || 8000 }, (req) => {
@@ -808,6 +861,11 @@ Deno.serve({ port: Number(Deno.env.get("PORT")) || 8000 }, (req) => {
     const u = new URL(req.url);
     u.pathname = "/member" + p;
     return memberFetch(new Request(u, req));
+  }
+  // Member app unavailable: intercept its own routes so they never render the
+  // OS desktop shell inside the member window (the Member/Web "Finder" bug).
+  if (!memberFetch && (p === "/member" || p.startsWith("/member/"))) {
+    return renderMemberUnavailable();
   }
   return legacyHandler(req);
 });


### PR DESCRIPTION
## Symptom

Opening **Member → Web** in Thirsty OS shows the Thirsty OS desktop (Apps / Demos / Member folders — the "Finder") inside the window instead of the Fresh member dashboard.

## Root cause

The OS "Web" icon loads `/member` in an iframe. `/member` is served by the vendored Fresh app **only if `member/_fresh/server.js` exists at runtime** (`memberFetch` is set). That build output is git-ignored and produced by `deno task build`.

When the build output is absent, `memberFetch` stays `null` and `/member` requests **fell through to `legacyHandler` → `renderOSShell()`** — which renders the entire Thirsty OS desktop. Inside the iframe that looks like the Web app "opening the Finder".

This is what's happening on the deployed site: the member app was never built for that environment.

## What this PR changes (`main.ts`)

- When the Fresh app is unavailable, `/member` and `/member/*` now return a clear **503 "Member app isn't built yet"** notice instead of silently falling through to the OS desktop shell. The Web window can never again masquerade as the Finder.
- The underlying dynamic-import error is captured and surfaced via an `x-member-load-error` response header to make the real failure diagnosable.

Non-member routes, asset hoisting, and the happy path (when `member/_fresh` *is* present) are unchanged.

## Remaining action to actually serve the dashboard in production

This PR removes the confusing symptom, but the dashboard only renders once the Fresh app is built for the deployment. `member/_fresh/` is git-ignored, so the deploy must run the build:

- **Build command:** `deno task build` (runs `deno task member:build` → `cd member && vite build`, emitting `member/_fresh/server.js`).
- Set that as the build command for the Deno Deploy app (it isn't currently running, which is why production shows the Finder). The build env needs access to `jsr.io` + `registry.npmjs.org`.

I couldn't run the build in the PR environment to commit a prebuilt `_fresh` because `jsr.io` is firewalled here (403), so I can't vendor `@fresh/plugin-vite`.

## Verification

- Type-check/runtime verification couldn't be fully run in-sandbox (`deno.land/std` + `jsr.io` are blocked), but the edited `main.ts` parses cleanly and the change is a small, self-contained branch in the request router.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyGaV2xufdfyp1jWwMoktJ)_