### PR TITLE
Kiosk: dark translucent badge backgrounds

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -324,6 +324,17 @@ function renderSPAShell(): Response {
     ::-webkit-scrollbar-thumb:hover { background: hsl(var(--muted-foreground)); }
     @keyframes spin { to { transform: rotate(360deg); } }
     .animate-spin { animation: spin 1s linear infinite; }
+    /* Status badges (Fire Sale / Available / Checked Out) drop their colored
+       tint for a uniform dark translucent fill, keeping their colored text and
+       border. !important is required to beat the Tailwind Play CDN's own
+       .bg-*\/15 utilities, which it injects into <head> after this block. The
+       class names carry a literal backslash (Tailwind escapes the "/"), doubled
+       here so the template literal emits a single "\". */
+    .bg-primary\\/15,
+    .bg-success\\/15,
+    .bg-warning\\/15 {
+      background-color: rgb(11 13 17 / 70%) !important;
+    }
   </style>
 </head>
 <body class="bg-background text-foreground antialiased">


### PR DESCRIPTION
## Change
Override the tinted status-badge fills in the Kiosk (Inventory Manager) — Fire Sale, Available, Checked Out (`.bg-primary/15`, `.bg-success/15`, `.bg-warning/15`) — to a uniform dark translucent background `rgb(11 13 17 / 70%)` (the app background `#0b0d11` at 70%), keeping each badge's colored text and border.

```css
.bg-primary\/15,
.bg-success\/15,
.bg-warning\/15 {
  background-color: rgb(11 13 17 / 70%) !important;
}
```

## Implementation notes
- Added to the SPA shell's inline `<style>` in `renderSPAShell()`.
- **`!important`** is required to beat the Tailwind Play CDN's own `.bg-*/15` utilities, which it injects into `<head>` *after* this static block.
- The selectors carry a literal backslash (Tailwind escapes the `/`). They live inside a JS template literal, so the backslash is **doubled in source** (`\\/`) to emit a single valid `\/` escape in the served HTML — verified the emitted markup contains `.bg-primary\/15` (not the invalid `.bg-primary/15`).

## Heads-up
`bg-success/15` and `bg-warning/15` are also used as the selected-row highlight in the samples list, so those selected backgrounds pick up the dark fill too. If the override should be scoped to badges only, that can be narrowed to the Badge component instead of the global utilities.

## Verification
- `deno check main.ts` — clean
- Emitted-HTML escaping confirmed via render check

🤖 Generated with [Claude Code](https://claude.com/claude-code)