### PR TITLE
[Apps/Product Analysis] Toggle price-recovery queue between unpriced & priced

### DIFF
--- a/static/inventory.html
+++ b/static/inventory.html
@@ -106,10 +106,9 @@
       <section class="panel" data-screen-label="Price recovery queue">
         <div class="section-head">
           <div>
-            <p class="eyebrow">Unpriced Samples</p>
-            <h2>Price Recovery Queue</h2>
+            <p class="eyebrow" id="queue-eyebrow">Unpriced Samples</p>
+            <h2 id="queue-title">Price Recovery Queue</h2>
           </div>
-          <span id="unpriced-summary" class="pill">Loading</span>
           <button class="panel-toggle" type="button" aria-expanded="true" aria-label="Toggle section">
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
           </button>
@@ -117,9 +116,20 @@
         <div class="panel-body">
           <div class="panel-body-inner">
             <div class="sample-toolbar">
-              <p id="unpriced-status" class="muted table-status">
-                Checking Graylog-backed sample rows.
-              </p>
+              <div class="toolbar-lead">
+                <button
+                  id="unpriced-summary"
+                  class="pill pill-toggle"
+                  type="button"
+                  data-mode="unpriced"
+                  aria-pressed="false"
+                >
+                  Loading
+                </button>
+                <p id="unpriced-status" class="muted table-status">
+                  Checking Graylog-backed sample rows.
+                </p>
+              </div>
               <button id="unpriced-refresh" class="ghost" type="button">
                 Refresh
               </button>

--- a/static/styles.css
+++ b/static/styles.css
@@ -462,6 +462,49 @@ section.panel.collapsed .panel-body {
   color: var(--accent);
 }
 
+/* The price-queue summary doubles as a toggle between the unpriced backlog and
+   the recovered (priced) list, so it renders as an interactive pill button --
+   reset the default button gradient back to the subtle badge look (keeping the
+   .pill border/shape) and carry a status dot whose color tracks the active view.
+   Scoped to .pill-toggle so other .pill badges keep the default treatment. */
+.pill-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--surface-2);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+
+.pill-toggle::before {
+  content: "";
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.pill-toggle[data-mode="priced"]::before {
+  background: var(--gold);
+}
+
+/* No active view to advertise while loading or unavailable -- drop the dot. */
+.pill-toggle[data-mode=""]::before {
+  display: none;
+}
+
+.pill-toggle:hover:not(:disabled) {
+  filter: none;
+  background: var(--surface-3);
+  border-color: var(--line-strong);
+}
+
+.pill-toggle:disabled {
+  cursor: not-allowed;
+}
+
 .valuation-grid {
   display: grid;
   gap: 10px;
@@ -515,6 +558,14 @@ section.panel.collapsed .panel-body {
   gap: 10px;
   justify-content: space-between;
   margin-bottom: 12px;
+}
+
+.toolbar-lead {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-width: 0;
 }
 
 .table-status {

--- a/static/ui.js
+++ b/static/ui.js
@@ -9,6 +9,13 @@ const defaultProductId = new URLSearchParams(location.search).get("product") ||
 
 let currentProductId = "";
 
+// The price-queue summary pill toggles which slice of the sample list is shown:
+// the unpriced backlog (default) or the rows whose prices have been recovered.
+// loadUnpricedSamples() caches the last response so toggling re-renders instantly
+// without another round-trip -- the list already carries both slices.
+let sampleView = "unpriced";
+let lastSampleData = null;
+
 // Launch clean: never replay a remembered/browser-restored search, and put the
 // cursor in the search box so the user can search or scan immediately. The
 // product details stay hidden until a search/scan actually loads a product.
@@ -74,6 +81,14 @@ document.getElementById("sample-intake").addEventListener("submit", (event) => {
 
 document.getElementById("unpriced-refresh").addEventListener("click", () => {
   loadUnpricedSamples();
+});
+
+// Flip between the unpriced backlog and the recovered (priced) list. The data is
+// already loaded, so just re-render the other slice -- no refetch.
+document.getElementById("unpriced-summary").addEventListener("click", () => {
+  if (!lastSampleData) return;
+  sampleView = sampleView === "unpriced" ? "priced" : "unpriced";
+  renderSamples();
 });
 
 document.getElementById("unpriced-rows").addEventListener(
@@ -148,7 +163,6 @@ async function loadProduct(productId) {
 }
 
 async function loadUnpricedSamples() {
-  const body = document.getElementById("unpriced-rows");
   const status = document.getElementById("unpriced-status");
   const summary = document.getElementById("unpriced-summary");
   const query = document.getElementById("global-query").value.trim();
@@ -156,27 +170,63 @@ async function loadUnpricedSamples() {
 
   if (query) params.set("query", query);
 
-  status.textContent = "Loading unpriced samples.";
+  status.textContent = "Loading samples.";
   summary.textContent = "Loading";
+  summary.disabled = true;
 
   try {
-    const data = await json(`/api/unpriced-samples?${params}`);
-    summary.textContent = `${count(data.unpricedCount)} unpriced | ${
-      count(data.pricedCount)
-    } priced`;
-    status.textContent = data.total
-      ? `${count(data.items.length)} of ${count(data.total)} sample rows shown.`
-      : "No unpriced samples matched this query.";
-    body.innerHTML = data.items.length
-      ? data.items.map(unpricedRowHtml).join("")
-      : `<div class="empty-row">No unpriced samples found.</div>`;
+    lastSampleData = await json(`/api/unpriced-samples?${params}`);
+    renderSamples();
   } catch (error) {
+    lastSampleData = null;
     status.textContent = error.message;
     summary.textContent = "Unavailable";
-    body.innerHTML = `<div class="empty-row">${
-      escapeHtml(error.message)
-    }</div>`;
+    summary.disabled = true;
+    // No view to advertise once the data is gone: clear the toggle affordance so
+    // a stale dot / pressed state doesn't linger on the "Unavailable" pill.
+    summary.dataset.mode = "";
+    summary.setAttribute("aria-pressed", "false");
+    document.getElementById("unpriced-rows").innerHTML =
+      `<div class="empty-row">${escapeHtml(error.message)}</div>`;
   }
+}
+
+// Render the cached sample list for the active view. The list response carries
+// every priced row plus the unpriced backlog up to the fetch limit, so each view
+// is just a filter on it; the summary pill, heading, and status all follow suit.
+function renderSamples() {
+  const data = lastSampleData;
+  if (!data) return;
+
+  const body = document.getElementById("unpriced-rows");
+  const status = document.getElementById("unpriced-status");
+  const summary = document.getElementById("unpriced-summary");
+  const eyebrow = document.getElementById("queue-eyebrow");
+  const title = document.getElementById("queue-title");
+
+  const priced = sampleView === "priced";
+  const label = priced ? "priced" : "unpriced";
+  const modeTotal = priced ? data.pricedCount : data.unpricedCount;
+  const rows = data.items.filter((sample) => sample.priced === priced);
+
+  eyebrow.textContent = priced ? "Priced Samples" : "Unpriced Samples";
+  title.textContent = priced ? "Recovered Prices" : "Price Recovery Queue";
+
+  summary.disabled = false;
+  summary.dataset.mode = label;
+  summary.setAttribute("aria-pressed", String(priced));
+  summary.title = priced
+    ? "Showing recovered prices — tap to see the unpriced backlog"
+    : "Showing the unpriced backlog — tap to see recovered prices";
+  summary.textContent = `${count(modeTotal)} ${label}`;
+
+  status.textContent = modeTotal
+    ? `${count(rows.length)} of ${count(modeTotal)} ${label} sample rows shown.`
+    : `No ${label} samples matched this query.`;
+
+  body.innerHTML = rows.length
+    ? rows.map(unpricedRowHtml).join("")
+    : `<div class="empty-row">No ${label} samples found.</div>`;
 }
 
 async function saveUnpricedSample(row) {


### PR DESCRIPTION
## What

Replaces the static `170 unpriced | 318 priced` summary badge in the Price Recovery Queue with an **interactive pill toggle**. Clicking it flips the whole list between the **unpriced backlog** and the **recovered (priced)** rows:

- **Pill label** shows only the active count + word — `170 unpriced` ⇄ `318 priced` — with a status dot (accent for unpriced, gold for priced).
- **List name** retitles: `Unpriced Samples / Price Recovery Queue` ⇄ `Priced Samples / Recovered Prices`.
- **Row contents** filter to the active slice.

## How

The slice switch is entirely client-side. The `/api/unpriced-samples` response already carries **every priced row** (they're the always-kept "edited" samples) plus the unpriced backlog up to the fetch limit, so each view is just a filter on the cached data — no refetch. `loadUnpricedSamples()` now caches the response and a new `renderSamples()` renders the active view; the pill toggles `sampleView` and re-renders instantly. No backend change.

The pill was moved into the queue **toolbar** (next to the status line), which also keeps it clear of the new collapse-on-header click handler. It renders via a scoped `.pill-toggle` class so other `.pill` badges keep the default treatment.

## Notes

- Rebased onto latest `main` (incl. collapsible panels); merges without conflict.
- `deno fmt` clean. The lone `deno lint` `no-window` warning is pre-existing on untouched `window.disableKiosk`.
- Verified by a multi-agent adversarial review (CSS specificity, JS logic/data assumptions, behavior-vs-request); the disabled/error-state nits it surfaced are fixed (correct `not-allowed` cursor, opacity fade, dot hidden + state reset when data is unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)