### PR TITLE
[Apps/Product Analysis] Sample toggle: show both pills, fix empty unpriced view

### DIFF
--- a/static/inventory.html
+++ b/static/inventory.html
@@ -117,15 +117,33 @@
           <div class="panel-body-inner">
             <div class="sample-toolbar">
               <div class="toolbar-lead">
-                <button
-                  id="unpriced-summary"
-                  class="pill pill-toggle"
-                  type="button"
-                  data-mode="unpriced"
-                  aria-pressed="false"
+                <div
+                  id="sample-view-toggle"
+                  class="view-toggle"
+                  role="group"
+                  aria-label="Show unpriced or priced samples"
                 >
-                  Loading
-                </button>
+                  <button
+                    id="view-unpriced"
+                    class="pill pill-toggle is-active"
+                    type="button"
+                    data-view="unpriced"
+                    aria-pressed="true"
+                    title="Show unpriced samples"
+                  >
+                    Unpriced
+                  </button>
+                  <button
+                    id="view-priced"
+                    class="pill pill-toggle"
+                    type="button"
+                    data-view="priced"
+                    aria-pressed="false"
+                    title="Show priced samples"
+                  >
+                    Priced
+                  </button>
+                </div>
                 <p id="unpriced-status" class="muted table-status">
                   Checking Graylog-backed sample rows.
                 </p>

--- a/static/styles.css
+++ b/static/styles.css
@@ -462,19 +462,26 @@ section.panel.collapsed .panel-body {
   color: var(--accent);
 }
 
-/* The price-queue summary doubles as a toggle between the unpriced backlog and
-   the recovered (priced) list, so it renders as an interactive pill button --
-   reset the default button gradient back to the subtle badge look (keeping the
-   .pill border/shape) and carry a status dot whose color tracks the active view.
-   Scoped to .pill-toggle so other .pill badges keep the default treatment. */
+/* The price-queue summary is a two-segment toggle: one pill per view (unpriced
+   backlog vs. recovered/priced rows), each showing its live count. The active
+   view is highlighted (matching the app's other active toggles) and made
+   non-interactive, so only the other pill is clickable. Each pill keeps the
+   .pill border/shape but resets the default button gradient, and carries a
+   status dot colored by its view. Scoped to .pill-toggle so other .pill badges
+   keep the default treatment. */
+.view-toggle {
+  display: inline-flex;
+  gap: 6px;
+}
+
 .pill-toggle {
   display: inline-flex;
   align-items: center;
   gap: 7px;
   background: var(--surface-2);
-  color: var(--text);
+  color: var(--text-dim);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .pill-toggle::before {
@@ -486,23 +493,24 @@ section.panel.collapsed .panel-body {
   background: var(--accent);
 }
 
-.pill-toggle[data-mode="priced"]::before {
+.pill-toggle[data-view="priced"]::before {
   background: var(--gold);
 }
 
-/* No active view to advertise while loading or unavailable -- drop the dot. */
-.pill-toggle[data-mode=""]::before {
-  display: none;
-}
-
-.pill-toggle:hover:not(:disabled) {
+.pill-toggle:not(.is-active):hover {
   filter: none;
   background: var(--surface-3);
   border-color: var(--line-strong);
+  color: var(--text);
 }
 
-.pill-toggle:disabled {
-  cursor: not-allowed;
+/* Active view: highlighted and not clickable -- only the other pill toggles. */
+.pill-toggle.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+  cursor: default;
+  pointer-events: none;
 }
 
 .valuation-grid {

--- a/static/ui.js
+++ b/static/ui.js
@@ -9,12 +9,21 @@ const defaultProductId = new URLSearchParams(location.search).get("product") ||
 
 let currentProductId = "";
 
-// The price-queue summary pill toggles which slice of the sample list is shown:
-// the unpriced backlog (default) or the rows whose prices have been recovered.
-// loadUnpricedSamples() caches the last response so toggling re-renders instantly
-// without another round-trip -- the list already carries both slices.
+// The price-queue summary is a two-pill toggle between the unpriced backlog
+// (default) and the rows whose prices have been recovered. loadUnpricedSamples()
+// fetches the full set once (see SAMPLE_LIMIT) and caches it, so flipping views
+// just re-filters the cached list -- no refetch.
 let sampleView = "unpriced";
 let lastSampleData = null;
+
+// Fetch the whole set in one shot so both views are complete. The backend keeps
+// every priced (edited) row in the page and fills the rest with the unpriced
+// backlog up to this limit; with priced rows able to outnumber a small limit,
+// anything lower would starve the unpriced slice. The product universe is capped
+// server-side (~1000), so this returns everything matched. Declared up here (not
+// beside loadUnpricedSamples) because that function runs during module init,
+// before a const lower in the file would leave its temporal dead zone.
+const SAMPLE_LIMIT = "1000";
 
 // Launch clean: never replay a remembered/browser-restored search, and put the
 // cursor in the search box so the user can search or scan immediately. The
@@ -83,13 +92,19 @@ document.getElementById("unpriced-refresh").addEventListener("click", () => {
   loadUnpricedSamples();
 });
 
-// Flip between the unpriced backlog and the recovered (priced) list. The data is
-// already loaded, so just re-render the other slice -- no refetch.
-document.getElementById("unpriced-summary").addEventListener("click", () => {
-  if (!lastSampleData) return;
-  sampleView = sampleView === "unpriced" ? "priced" : "unpriced";
-  renderSamples();
-});
+// Flip between the unpriced backlog and the recovered (priced) list. Only the
+// inactive pill is clickable (the active one has pointer-events: none), so a
+// click always names the view to switch to; re-render from cached data.
+document.getElementById("sample-view-toggle").addEventListener(
+  "click",
+  (event) => {
+    const pill = event.target.closest("button[data-view]");
+    if (!pill || !lastSampleData) return;
+    if (pill.dataset.view === sampleView) return;
+    sampleView = pill.dataset.view;
+    renderSamples();
+  },
+);
 
 document.getElementById("unpriced-rows").addEventListener(
   "click",
@@ -164,15 +179,12 @@ async function loadProduct(productId) {
 
 async function loadUnpricedSamples() {
   const status = document.getElementById("unpriced-status");
-  const summary = document.getElementById("unpriced-summary");
   const query = document.getElementById("global-query").value.trim();
-  const params = new URLSearchParams({ limit: "150" });
+  const params = new URLSearchParams({ limit: SAMPLE_LIMIT });
 
   if (query) params.set("query", query);
 
   status.textContent = "Loading samples.";
-  summary.textContent = "Loading";
-  summary.disabled = true;
 
   try {
     lastSampleData = await json(`/api/unpriced-samples?${params}`);
@@ -180,45 +192,41 @@ async function loadUnpricedSamples() {
   } catch (error) {
     lastSampleData = null;
     status.textContent = error.message;
-    summary.textContent = "Unavailable";
-    summary.disabled = true;
-    // No view to advertise once the data is gone: clear the toggle affordance so
-    // a stale dot / pressed state doesn't linger on the "Unavailable" pill.
-    summary.dataset.mode = "";
-    summary.setAttribute("aria-pressed", "false");
     document.getElementById("unpriced-rows").innerHTML =
       `<div class="empty-row">${escapeHtml(error.message)}</div>`;
   }
 }
 
-// Render the cached sample list for the active view. The list response carries
-// every priced row plus the unpriced backlog up to the fetch limit, so each view
-// is just a filter on it; the summary pill, heading, and status all follow suit.
+// Render the cached sample list for the active view. The response carries every
+// matched row plus both totals, so each view is a filter on it; both pills always
+// show their count, the active one is highlighted, and heading/status follow.
 function renderSamples() {
   const data = lastSampleData;
   if (!data) return;
 
   const body = document.getElementById("unpriced-rows");
   const status = document.getElementById("unpriced-status");
-  const summary = document.getElementById("unpriced-summary");
+  const unpricedPill = document.getElementById("view-unpriced");
+  const pricedPill = document.getElementById("view-priced");
   const eyebrow = document.getElementById("queue-eyebrow");
   const title = document.getElementById("queue-title");
 
   const priced = sampleView === "priced";
   const label = priced ? "priced" : "unpriced";
-  const modeTotal = priced ? data.pricedCount : data.unpricedCount;
-  const rows = data.items.filter((sample) => sample.priced === priced);
+
+  // Both pills always show their live count; only the inactive one is clickable.
+  unpricedPill.textContent = `${count(data.unpricedCount)} unpriced`;
+  pricedPill.textContent = `${count(data.pricedCount)} priced`;
+  unpricedPill.classList.toggle("is-active", !priced);
+  pricedPill.classList.toggle("is-active", priced);
+  unpricedPill.setAttribute("aria-pressed", String(!priced));
+  pricedPill.setAttribute("aria-pressed", String(priced));
 
   eyebrow.textContent = priced ? "Priced Samples" : "Unpriced Samples";
   title.textContent = priced ? "Recovered Prices" : "Price Recovery Queue";
 
-  summary.disabled = false;
-  summary.dataset.mode = label;
-  summary.setAttribute("aria-pressed", String(priced));
-  summary.title = priced
-    ? "Showing recovered prices — tap to see the unpriced backlog"
-    : "Showing the unpriced backlog — tap to see recovered prices";
-  summary.textContent = `${count(modeTotal)} ${label}`;
+  const modeTotal = priced ? data.pricedCount : data.unpricedCount;
+  const rows = data.items.filter((sample) => sample.priced === priced);
 
   status.textContent = modeTotal
     ? `${count(rows.length)} of ${count(modeTotal)} ${label} sample rows shown.`


### PR DESCRIPTION
Follow-up to #54 (now merged), addressing two issues spotted in the live app.

## 1. Unpriced view was empty 🐛
The queue showed **"No unpriced samples found"** ("0 of 170") even with a large backlog. The list is fetched once and filtered client-side, but the backend always keeps **every** priced (edited) row in the page and only fills the *remaining* limit with the unpriced backlog. Once priced rows (318) outnumber the fetch limit (150), the unpriced slice was starved to **zero** — so the client had no unpriced rows to show.

**Fix:** raise the fetch limit so the whole set comes back. The product universe is capped server-side (~1000), so one generous limit returns everything matched, and both views filter correctly. No backend change.

## 2. Show both pills, only the inactive one clickable
Per feedback, the summary now shows **both** counts at once as a two-pill segmented control — `N unpriced` and `N priced` — instead of one flipping label. The active view is highlighted (matching the app's existing active-toggle style) and made non-interactive (`pointer-events: none` + a guard), so only the inactive pill is clickable to switch.

Switching still flips the heading (`Unpriced Samples / Price Recovery Queue` ⇄ `Priced Samples / Recovered Prices`), row contents, and status — all from cached data, no refetch.

## Verification
Driven end-to-end in a browser against a stubbed API (real `ui.js`/HTML/CSS):
- Default **Unpriced**: "4 unpriced" active + non-clickable, "3 priced" clickable, 4 rows, "4 of 4 unpriced sample rows shown." ✅ (the empty-view bug is fixed)
- Click **priced** → "Recovered Prices", priced pill active, unpriced clickable, 3 rows. ✅
- Clicking the active pill is a no-op; **Refresh** preserves the active view. ✅
- Dot colors confirmed via computed style (unpriced = accent, priced = gold). ✅

The runtime test also caught a `const` temporal-dead-zone crash (`SAMPLE_LIMIT` referenced before init during module load) that `deno fmt`/`lint` did not — fixed by hoisting the declaration above the top-level init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)