### PR TITLE
Add Barcode Lookup fallback + UPC candidate normalization

### DIFF
--- a/core/samples.ts
+++ b/core/samples.ts
@@ -488,8 +488,11 @@ const DEFAULT_UPCITEMDB_URL = "https://api.upcitemdb.com/prod/trial/lookup";
 // Go-UPC fallback: a much larger (500M+) catalog that covers general consumer
 // goods UPCitemdb's free trial misses. Keyed (GOUPC_API_KEY) — skipped if unset.
 const DEFAULT_GOUPC_URL = "https://go-upc.com/api/v1/code";
+// Barcode Lookup fallback: another large independent catalog. Keyed
+// (BARCODELOOKUP_API_KEY) — skipped if unset.
+const DEFAULT_BARCODELOOKUP_URL = "https://api.barcodelookup.com/v3/products";
 // Open Food Facts fallback: free, no key, no rate limit. Food/grocery/cosmetics
-// focused — the last-resort provider when both keyed sources come up empty.
+// focused — the last-resort provider when the keyed sources come up empty.
 const DEFAULT_OPENFOODFACTS_URL = "https://world.openfoodfacts.org/api/v2/product";
 
 export type UpcItem = {
@@ -509,7 +512,7 @@ export type UpcMatch = {
 };
 
 // Providers in the lookup chain (diagnostics for the caller).
-export type UpcSource = "upcitemdb" | "go-upc" | "openfoodfacts";
+export type UpcSource = "upcitemdb" | "go-upc" | "barcodelookup" | "openfoodfacts";
 
 export type UpcLookup = {
   ok: boolean;
@@ -574,6 +577,36 @@ async function fetchGoUpcItem(upc: string, key: string): Promise<UpcItem | null>
   };
 }
 
+// Barcode Lookup: GET /v3/products?barcode=<upc>&key=<key>. 404 = not in their
+// database; otherwise a { products: [ { product_name, brand, category } ] } list.
+async function fetchBarcodeLookupItem(upc: string, key: string): Promise<UpcItem | null> {
+  const base = (envValue("BARCODELOOKUP_API_URL") || DEFAULT_BARCODELOOKUP_URL)
+    .replace(/\/+$/, "");
+  const url = new URL(base);
+  url.searchParams.set("barcode", upc);
+  url.searchParams.set("key", key);
+
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Barcode Lookup failed: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  const product = isRecord(body) && Array.isArray(body.products) ? body.products[0] : null;
+  if (!isRecord(product)) return null;
+  const title = product.product_name
+    ? String(product.product_name).trim()
+    : product.title
+    ? String(product.title).trim()
+    : "";
+  if (!title) return null;
+  return {
+    title,
+    brand: product.brand ? String(product.brand) : null,
+    category: product.category ? String(product.category) : null,
+  };
+}
+
 // Open Food Facts: free, keyless. GET /api/v2/product/<upc>.json — status 0 (or
 // HTTP 404) means the barcode isn't in the open database. `brands`/`categories`
 // come back as comma lists: take the first brand and the most-specific category.
@@ -615,49 +648,73 @@ type UpcItemResult = {
   providersTried: UpcSource[];
 };
 
+// A scanned code may arrive as UPC-A (12 digits) or zero-padded EAN-13 (13).
+// Try the as-given form first, then the alternate, so a provider that only
+// indexes one representation still resolves. Deduped, order-preserving.
+function upcCandidates(upc: string): string[] {
+  const out = [upc];
+  if (upc.length === 13 && upc.startsWith("0")) {
+    out.push(upc.slice(1)); // EAN-13 leading zero → UPC-A (12)
+  } else if (upc.length === 12) {
+    out.push("0" + upc); // UPC-A → EAN-13
+  }
+  return [...new Set(out)];
+}
+
 // Resolve a UPC to a product, walking a provider chain so a single source's
 // gap (or the trial endpoint's ~100/day cap) doesn't strand the lookup:
-//   UPCitemdb → Go-UPC (when GOUPC_API_KEY is set) → Open Food Facts (free).
-// Records every provider attempted (providersTried) and which one answered
-// (source). A provider error is only fatal when *every* attempt threw —
-// otherwise a clean miss from any source means a genuine "not found".
+//   UPCitemdb → Go-UPC → Barcode Lookup (each keyed) → Open Food Facts (free).
+// Each provider is tried across every UPC candidate form. Records every
+// provider attempted (providersTried) and which one answered (source). A
+// provider error is only fatal when *every* attempt threw — otherwise a clean
+// miss from any source means a genuine "not found".
 async function fetchUpcItem(upc: string): Promise<UpcItemResult> {
+  const candidates = upcCandidates(upc);
   const providersTried: UpcSource[] = [];
   let primaryError: unknown = null;
   let anyAnswered = false; // a provider responded cleanly (hit or definitive miss)
 
-  // 1. UPCitemdb
-  providersTried.push("upcitemdb");
-  try {
-    const item = await fetchUpcItemDb(upc);
-    anyAnswered = true;
-    if (item) return { item, source: "upcitemdb", providersTried };
-  } catch (error) {
-    primaryError = error; // e.g. a 429 from the shared trial endpoint
-  }
+  // Run one provider across all UPC candidate forms. Returns the first hit, or
+  // null on a clean miss. Marks anyAnswered when the provider responds without
+  // throwing, and captures UPCitemdb's error as the primary failure.
+  const run = async (
+    source: UpcSource,
+    fn: (u: string) => Promise<UpcItem | null>,
+  ): Promise<UpcItem | null> => {
+    providersTried.push(source);
+    let answered = false;
+    let firstError: unknown = null;
+    for (const candidate of candidates) {
+      try {
+        const item = await fn(candidate);
+        answered = true;
+        if (item) return item;
+      } catch (error) {
+        if (firstError === null) firstError = error;
+      }
+    }
+    if (answered) anyAnswered = true;
+    else if (source === "upcitemdb" && firstError !== null) primaryError = firstError;
+    return null;
+  };
 
-  // 2. Go-UPC (only when a key is configured)
+  let item = await run("upcitemdb", fetchUpcItemDb);
+  if (item) return { item, source: "upcitemdb", providersTried };
+
   const goUpcKey = envValue("GOUPC_API_KEY");
   if (goUpcKey) {
-    providersTried.push("go-upc");
-    try {
-      const item = await fetchGoUpcItem(upc, goUpcKey);
-      anyAnswered = true;
-      if (item) return { item, source: "go-upc", providersTried };
-    } catch {
-      // A miss/credit error shouldn't mask a real primary failure.
-    }
+    item = await run("go-upc", (u) => fetchGoUpcItem(u, goUpcKey));
+    if (item) return { item, source: "go-upc", providersTried };
   }
 
-  // 3. Open Food Facts (free, keyless last resort)
-  providersTried.push("openfoodfacts");
-  try {
-    const item = await fetchOpenFoodFactsItem(upc);
-    anyAnswered = true;
-    if (item) return { item, source: "openfoodfacts", providersTried };
-  } catch {
-    // An OFF outage shouldn't be fatal on its own.
+  const barcodeLookupKey = envValue("BARCODELOOKUP_API_KEY");
+  if (barcodeLookupKey) {
+    item = await run("barcodelookup", (u) => fetchBarcodeLookupItem(u, barcodeLookupKey));
+    if (item) return { item, source: "barcodelookup", providersTried };
   }
+
+  item = await run("openfoodfacts", fetchOpenFoodFactsItem);
+  if (item) return { item, source: "openfoodfacts", providersTried };
 
   // Nothing matched. If at least one provider answered, it's a genuine miss; if
   // they ALL errored, surface the primary failure so the caller returns 502.

--- a/main.ts
+++ b/main.ts
@@ -703,9 +703,9 @@ export async function legacyHandler(req: Request): Promise<Response> {
       }
 
       // Scanned-barcode lookup for the tracker's Barcode Test page: resolve a
-      // UPC to a product name via UPCitemdb (falling back to Go-UPC, then Open
-      // Food Facts), then find the matching TikTok product via ScrapeCreators.
-      // Cross-origin GET, so it carries CORS.
+      // UPC to a product name via UPCitemdb (falling back to Go-UPC, Barcode
+      // Lookup, then Open Food Facts), then find the matching TikTok product via
+      // ScrapeCreators. Cross-origin GET, so it carries CORS.
       const upcMatch = url.pathname.match(/^\/api\/upc-lookup\/([^/]+)$/i);
       if (upcMatch) {
         if (req.method !== "GET") {


### PR DESCRIPTION
## Why

Continues the UPC fallback work (#60, #61). For barcode `0631656718577` all three existing providers ran and genuinely missed. This adds a fourth source and hardens the lookup against UPC-A/EAN-13 representation mismatches.

## Changes (`core/samples.ts`)

**1. Barcode Lookup provider (`fetchBarcodeLookupItem`)** — added after Go-UPC in the chain:
```
UPCitemdb → Go-UPC → Barcode Lookup → Open Food Facts
```
`GET /v3/products?barcode=<upc>&key=<key>`; 404 = not found; reads `product_name`/`title`, `brand`, `category` from the first `products[]` entry. Keyed via **`BARCODELOOKUP_API_KEY`** (skipped if unset), endpoint overridable with `BARCODELOOKUP_API_URL`. `barcodelookup` now appears in `providersTried`/`source`.

**2. UPC candidate normalization (`upcCandidates`)** — each provider is now tried against both the as-scanned code and its alternate form:
- 13-digit with leading zero → also try the 12-digit UPC-A (`0631656718577` → `631656718577`)
- 12-digit → also try the zero-padded EAN-13

This catches misses where a database indexes a barcode under only one representation. The second form is only attempted when the first misses, so it adds at most one extra call per provider.

The per-provider runner (`run`) handles candidate iteration plus error capture, preserving the existing rule that a provider error is only fatal (502) when *every* attempt threw.

## Config

| Var | Purpose |
|---|---|
| `BARCODELOOKUP_API_KEY` | Barcode Lookup key (fallback #2). Unset ⇒ skipped. |
| `BARCODELOOKUP_API_URL` | Override Barcode Lookup endpoint. |

(`GOUPC_API_KEY`, `GOUPC_API_URL`, `OPENFOODFACTS_API_URL` from prior PRs still apply.)

## Testing

Could not run `deno check` or hit the live APIs from the CI sandbox (no Deno; egress to the provider hosts and `thirsty.store` is blocked). Relying on the Deno Deploy build as the compile check and the live endpoint for runtime verification. Recommend `deno task check` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuEEf5BA8rrpw542XRv6Vs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuEEf5BA8rrpw542XRv6Vs)_