### PR TITLE
Add Google Lens (SerpApi) visual-match fallback for unindexed barcodes

### DIFF
--- a/core/barcode.ts
+++ b/core/barcode.ts
@@ -1,0 +1,29 @@
+import bwipjs from "npm:bwip-js@^4";
+
+// Render a UPC/EAN code as a PNG barcode. The symbology is chosen from the
+// digit count — EAN-13 (13), UPC-A (12) — falling back to Code 128 so any
+// scanned string still produces a scannable image. Exists so the UPC lookup's
+// Google Lens fallback has a public image of the barcode to visually match.
+export async function renderBarcodePng(code: string): Promise<Uint8Array> {
+  const digits = code.replace(/\D/g, "");
+  let bcid = "code128";
+  let text = code;
+  if (digits.length === 13) {
+    bcid = "ean13";
+    text = digits;
+  } else if (digits.length === 12) {
+    bcid = "upca";
+    text = digits;
+  }
+
+  const png = await bwipjs.toBuffer({
+    bcid,
+    text,
+    scale: 3,
+    height: 12,
+    includetext: true,
+    textxalign: "center",
+  });
+  // toBuffer yields a Node Buffer; hand back a plain Uint8Array for the Response.
+  return new Uint8Array(png);
+}

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -494,6 +494,10 @@ const DEFAULT_BARCODELOOKUP_URL = "https://api.barcodelookup.com/v3/products";
 // Open Food Facts fallback: free, no key, no rate limit. Food/grocery/cosmetics
 // focused — the last-resort provider when the keyed sources come up empty.
 const DEFAULT_OPENFOODFACTS_URL = "https://world.openfoodfacts.org/api/v2/product";
+// Google Lens (via SerpApi): the visual-search escape hatch for barcodes no UPC
+// database indexes. We render the code as a barcode image and let Lens decode +
+// match it against Google's shopping graph. Keyed (SERPAPI_API_KEY).
+const DEFAULT_SERPAPI_URL = "https://serpapi.com/search.json";
 
 export type UpcItem = {
   title: string;
@@ -512,7 +516,12 @@ export type UpcMatch = {
 };
 
 // Providers in the lookup chain (diagnostics for the caller).
-export type UpcSource = "upcitemdb" | "go-upc" | "barcodelookup" | "openfoodfacts";
+export type UpcSource =
+  | "upcitemdb"
+  | "go-upc"
+  | "barcodelookup"
+  | "openfoodfacts"
+  | "googlelens";
 
 export type UpcLookup = {
   ok: boolean;
@@ -642,6 +651,50 @@ async function fetchOpenFoodFactsItem(upc: string): Promise<UpcItem | null> {
   return { title, brand, category: cats.length ? cats[cats.length - 1] : null };
 }
 
+// Lens/shopping titles carry retail noise ("Buy …", "… - Walmart.com"). Trim the
+// leading verb and any trailing " - site" / " | site" suffix so the name we feed
+// the TikTok search is the product, not the storefront.
+function cleanLensTitle(raw: string): string {
+  return raw
+    .replace(/^\s*(buy|shop|get|order)\s+/i, "")
+    .split(/\s+[|–—]\s+|\s+-\s+(?=\S+\.\w{2,}|\w+\.com)/i)[0]
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Google Lens via SerpApi. We point Lens at our own rendered barcode image
+// (served by /api/barcode/<upc>.png) so it decodes the code and returns the
+// shopping "visual_matches" — resolving products no UPC database indexes. Needs
+// a publicly reachable base URL for the image, hence publicBase.
+async function fetchGoogleLensItem(
+  upc: string,
+  key: string,
+  publicBase: string,
+): Promise<UpcItem | null> {
+  const imageUrl = `${publicBase.replace(/\/+$/, "")}/api/barcode/${
+    encodeURIComponent(upc)
+  }.png`;
+  const url = new URL(envValue("SERPAPI_API_URL") || DEFAULT_SERPAPI_URL);
+  url.searchParams.set("engine", "google_lens");
+  url.searchParams.set("url", imageUrl);
+  url.searchParams.set("api_key", key);
+
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(`Google Lens lookup failed: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  const matches = isRecord(body) && Array.isArray(body.visual_matches)
+    ? body.visual_matches
+    : [];
+  for (const match of matches) {
+    if (!isRecord(match) || !match.title) continue;
+    const title = cleanLensTitle(String(match.title));
+    if (title) return { title, brand: null, category: null };
+  }
+  return null;
+}
+
 type UpcItemResult = {
   item: UpcItem | null;
   source: UpcSource | null;
@@ -663,28 +716,33 @@ function upcCandidates(upc: string): string[] {
 
 // Resolve a UPC to a product, walking a provider chain so a single source's
 // gap (or the trial endpoint's ~100/day cap) doesn't strand the lookup:
-//   UPCitemdb → Go-UPC → Barcode Lookup (each keyed) → Open Food Facts (free).
-// Each provider is tried across every UPC candidate form. Records every
-// provider attempted (providersTried) and which one answered (source). A
-// provider error is only fatal when *every* attempt threw — otherwise a clean
-// miss from any source means a genuine "not found".
-async function fetchUpcItem(upc: string): Promise<UpcItemResult> {
+//   UPCitemdb → Go-UPC → Barcode Lookup (each keyed) → Open Food Facts (free)
+//   → Google Lens (SerpApi; visual barcode match for codes no DB indexes).
+// Each provider is tried across every UPC candidate form (Lens excepted — it
+// costs a SerpApi credit per call, so it runs once on the scanned code).
+// Records every provider attempted (providersTried) and which one answered
+// (source). A provider error is only fatal when *every* attempt threw —
+// otherwise a clean miss from any source means a genuine "not found".
+// publicBase is the externally reachable origin Lens fetches the barcode from.
+async function fetchUpcItem(upc: string, publicBase: string): Promise<UpcItemResult> {
   const candidates = upcCandidates(upc);
   const providersTried: UpcSource[] = [];
   let primaryError: unknown = null;
   let anyAnswered = false; // a provider responded cleanly (hit or definitive miss)
 
-  // Run one provider across all UPC candidate forms. Returns the first hit, or
-  // null on a clean miss. Marks anyAnswered when the provider responds without
-  // throwing, and captures UPCitemdb's error as the primary failure.
+  // Run one provider across the given UPC candidate forms (defaulting to all).
+  // Returns the first hit, or null on a clean miss. Marks anyAnswered when the
+  // provider responds without throwing, and captures UPCitemdb's error as the
+  // primary failure.
   const run = async (
     source: UpcSource,
     fn: (u: string) => Promise<UpcItem | null>,
+    cands: string[] = candidates,
   ): Promise<UpcItem | null> => {
     providersTried.push(source);
     let answered = false;
     let firstError: unknown = null;
-    for (const candidate of candidates) {
+    for (const candidate of cands) {
       try {
         const item = await fn(candidate);
         answered = true;
@@ -716,6 +774,19 @@ async function fetchUpcItem(upc: string): Promise<UpcItemResult> {
   item = await run("openfoodfacts", fetchOpenFoodFactsItem);
   if (item) return { item, source: "openfoodfacts", providersTried };
 
+  // Last resort: visual barcode match via Google Lens. Needs a key and a
+  // public origin for the rendered barcode image; runs once (not per candidate)
+  // to conserve SerpApi credits.
+  const serpApiKey = envValue("SERPAPI_API_KEY");
+  if (serpApiKey && publicBase) {
+    item = await run(
+      "googlelens",
+      (u) => fetchGoogleLensItem(u, serpApiKey, publicBase),
+      [upc],
+    );
+    if (item) return { item, source: "googlelens", providersTried };
+  }
+
   // Nothing matched. If at least one provider answered, it's a genuine miss; if
   // they ALL errored, surface the primary failure so the caller returns 502.
   if (!anyAnswered && primaryError) throw primaryError;
@@ -730,11 +801,18 @@ function productIdFromUrl(sourceUrl: string | undefined): string | null {
   return m ? m[1] : null;
 }
 
-export async function lookupProductByUpc(upc: string): Promise<UpcLookup> {
+// `origin` is the request's public origin, used to build the barcode-image URL
+// for the Google Lens fallback. PUBLIC_BASE_URL overrides it when the request
+// origin isn't externally reachable (e.g. behind an internal proxy).
+export async function lookupProductByUpc(
+  upc: string,
+  opts: { origin?: string } = {},
+): Promise<UpcLookup> {
   const clean = String(upc || "").replace(/\D/g, "");
   if (!clean) throw new Error("upc is required");
 
-  const { item, source, providersTried } = await fetchUpcItem(clean);
+  const publicBase = envValue("PUBLIC_BASE_URL") || opts.origin || "";
+  const { item, source, providersTried } = await fetchUpcItem(clean, publicBase);
   if (!item) {
     return {
       ok: false,

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import {
   upsertSampleProduct,
 } from "./core/samples.ts";
 import { envValue, graylogConfigFromEnv } from "./core/graylog.ts";
+import { renderBarcodePng } from "./core/barcode.ts";
 
 const pool = new Pool({
   connectionString: Deno.env.get("DATABASE_URL"),
@@ -704,8 +705,8 @@ export async function legacyHandler(req: Request): Promise<Response> {
 
       // Scanned-barcode lookup for the tracker's Barcode Test page: resolve a
       // UPC to a product name via UPCitemdb (falling back to Go-UPC, Barcode
-      // Lookup, then Open Food Facts), then find the matching TikTok product via
-      // ScrapeCreators. Cross-origin GET, so it carries CORS.
+      // Lookup, Open Food Facts, then a Google Lens visual match), then find the
+      // matching TikTok product via ScrapeCreators. Cross-origin GET, carries CORS.
       const upcMatch = url.pathname.match(/^\/api\/upc-lookup\/([^/]+)$/i);
       if (upcMatch) {
         if (req.method !== "GET") {
@@ -713,10 +714,35 @@ export async function legacyHandler(req: Request): Promise<Response> {
         }
         const upc = decodeURIComponent(upcMatch[1]);
         try {
-          return corsJson(await lookupProductByUpc(upc));
+          return corsJson(await lookupProductByUpc(upc, { origin: url.origin }));
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return corsJson({ ok: false, upc, error: msg }, 502);
+        }
+      }
+
+      // Render a UPC as a barcode PNG. Backs the UPC lookup's Google Lens
+      // fallback: SerpApi fetches this image so Lens can decode the barcode and
+      // match products no UPC database indexes. Public GET (image, not JSON).
+      const barcodeMatch = url.pathname.match(/^\/api\/barcode\/([^/]+?)\.png$/i);
+      if (barcodeMatch) {
+        if (req.method !== "GET") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        const upc = decodeURIComponent(barcodeMatch[1]).replace(/\D/g, "");
+        try {
+          const png = await renderBarcodePng(upc);
+          return new Response(png, {
+            status: 200,
+            headers: {
+              "content-type": "image/png",
+              "cache-control": "public, max-age=86400",
+              "access-control-allow-origin": "*",
+            },
+          });
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson({ ok: false, upc, error: msg }, 400);
         }
       }
 


### PR DESCRIPTION
## Why

Continues the UPC fallback work (#60, #61, #62). Some barcodes — e.g. `0631656718577` (**MuscleTech Platinum 100% Creatine**) — aren't in *any* UPC database (UPCitemdb, Go-UPC, Barcode Lookup, Open Food Facts all miss), yet **Google Lens resolves them**: Lens decodes the barcode *image* and matches it against Google's shopping graph, which has the product even though the number isn't in a queryable DB. This adds a final fallback that replicates that programmatically.

## How it works

When all four databases miss, the lookup:
1. Renders the UPC as a barcode PNG — new `core/barcode.ts` (bwip-js), served at **`GET /api/barcode/<upc>.png`** (EAN-13/UPC-A by digit count, Code 128 otherwise).
2. Points **SerpApi's Google Lens engine** (`engine=google_lens`) at that image URL.
3. Takes the best `visual_matches[]` title (lightly de-noised of "Buy …"/storefront suffixes) as the product name, which then feeds the existing ScrapeCreators TikTok search.

Full chain:
```
UPCitemdb → Go-UPC → Barcode Lookup → Open Food Facts → Google Lens (SerpApi)
```

Reported as `source`/`providersTried`: **`googlelens`**.

## Details

- **Keyed** via `SERPAPI_API_KEY`; skipped if unset. Runs **only after all DBs miss**, and **only once** (not per UPC candidate form) to conserve SerpApi credits.
- Needs a publicly reachable origin for the barcode image: uses the request origin, overridable with **`PUBLIC_BASE_URL`** (set this if the app sits behind an internal proxy).
- `lookupProductByUpc(upc, { origin })` — new optional second arg; `main.ts` passes `url.origin`.

## Config

| Var | Purpose |
|---|---|
| `SERPAPI_API_KEY` | SerpApi key for the Google Lens fallback. Unset ⇒ skipped. |
| `SERPAPI_API_URL` | Override SerpApi endpoint. |
| `PUBLIC_BASE_URL` | Public origin for the barcode image (defaults to request origin). |

## Testing / risk

Could not run `deno check` or exercise the providers from the CI sandbox (no Deno; egress to SerpApi/npm/`thirsty.store` blocked). Two things to watch on deploy:
1. **New npm dep** `bwip-js@^4` — `deno.lock` will be updated by the Deno Deploy build; watch the build status.
2. **`bwip-js` in Deno Deploy** uses node `zlib`/`Buffer` compat for PNG encoding — verify `/api/barcode/<upc>.png` renders at runtime.
3. **Generated-barcode decodes in Lens** — needs a live check that Lens resolves our rendered image the same way it resolved the physical scan.

Recommend `deno task check` plus a manual hit of `/api/barcode/0631656718577.png` and the live lookup before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuEEf5BA8rrpw542XRv6Vs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuEEf5BA8rrpw542XRv6Vs)_