### PR TITLE
Make ScrapeCreators price lookup resilient instead of 500-ing the dashboard

### DIFF
--- a/core/samples.ts
+++ b/core/samples.ts
@@ -1124,6 +1124,28 @@ function matchesQuery(sample: UnpricedSample, query: string): boolean {
     sample.notes.toLowerCase().includes(query);
 }
 
+// Retry transient ScrapeCreators failures (5xx/429) a few times with linear
+// backoff. Their endpoints occasionally fault on requests they can otherwise
+// serve, and a short retry recovers the accurate result without resorting to a
+// less-precise fallback lookup.
+async function fetchWithRetry(
+  url: URL,
+  init: RequestInit,
+  attempts = 3,
+): Promise<Response> {
+  let response!: Response;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    response = await fetch(url, init);
+    if (response.status < 500 && response.status !== 429) return response;
+    if (attempt < attempts - 1) {
+      // Drain the unused body so the connection can be reused, then back off.
+      await response.body?.cancel();
+      await new Promise((resolve) => setTimeout(resolve, 300 * (attempt + 1)));
+    }
+  }
+  return response;
+}
+
 async function fetchScrapeCreatorsPrice(
   product: ProductAnalysis,
 ): Promise<ScrapeCreatorsPrice> {
@@ -1135,11 +1157,34 @@ async function fetchScrapeCreatorsPrice(
       .replace(/\/+$/, "");
   const region = envValue("SCRAPECREATORS_REGION") || DEFAULT_REGION;
 
+  // Synthetic "9"-prefixed ids never map to a real PDP, so go straight to the
+  // name search.
   if (product.productId.startsWith("9")) {
     return fetchScrapeCreatorsPriceByName(base, apiKey, region, product);
   }
 
-  return fetchScrapeCreatorsPriceByUrl(base, apiKey, region, product);
+  // Prefer the by-URL lookup -- when it works it returns the exact PDP's price.
+  // But that endpoint is flaky (ScrapeCreators intermittently 500s with "Cannot
+  // set properties of undefined (setting 'related_videos')" on products it can
+  // otherwise resolve) and some products never resolve, so fall back to the
+  // name search instead of failing the whole request. The fallback may match a
+  // different listing for the same product, which still beats no price at all.
+  try {
+    const byUrl = await fetchScrapeCreatorsPriceByUrl(
+      base,
+      apiKey,
+      region,
+      product,
+    );
+    if (byUrl.price > 0) return byUrl;
+  } catch (error) {
+    console.error(
+      "ScrapeCreators by-url lookup failed; trying name search:",
+      error,
+    );
+  }
+
+  return fetchScrapeCreatorsPriceByName(base, apiKey, region, product);
 }
 
 async function fetchScrapeCreatorsPriceByUrl(
@@ -1153,7 +1198,10 @@ async function fetchScrapeCreatorsPriceByUrl(
   url.searchParams.set("url", productUrl);
   url.searchParams.set("region", region);
 
-  const response = await fetch(url, {
+  // This endpoint intermittently 500s on products it can otherwise resolve, so
+  // retry transient 5xx/429 before giving up -- a retry usually returns the
+  // correct PDP price (and only then do we fall back to the name search).
+  const response = await fetchWithRetry(url, {
     headers: {
       "accept": "application/json",
       "content-type": "application/json",

--- a/main.ts
+++ b/main.ts
@@ -796,7 +796,16 @@ export async function legacyHandler(req: Request): Promise<Response> {
       const fetchPriceMatch = url.pathname.match(/^\/api\/unpriced-samples\/([^/]+)\/fetch-price$/i);
       if (fetchPriceMatch) {
         if (req.method !== "POST") return json({ ok: false, error: "Method not allowed" }, 405);
-        return json(await fetchPriceForSample(decodeURIComponent(fetchPriceMatch[1])));
+        try {
+          return json(await fetchPriceForSample(decodeURIComponent(fetchPriceMatch[1])));
+        } catch (error) {
+          // A ScrapeCreators miss/outage (or a product missing from Graylog)
+          // must not surface as a raw 500 stack trace -- return a clean error
+          // like the sibling /api/product-lookup and /api/upc-lookup routes so
+          // the row simply stays unpriced.
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 502);
+        }
       }
 
       if (pathname === "/api/comparison") {


### PR DESCRIPTION
## What & why

Clicking **Look Up Price** on an unpriced sample (POST `/api/unpriced-samples/:id/fetch-price`) could nuke the entire Product Analysis panel with a raw 500 stack-trace banner:

> Error: ScrapeCreators lookup failed: 500 {"success":false,"credits_remaining":34,"error":"internal_server_error","errorStatus":500,"message":"Cannot set properties of undefined (setting 'related_videos')"} at fetchScrapeCreatorsPriceByUrl … at fetchPriceForSample … at legacyHandler …

That `internal_server_error` / `related_videos` envelope comes from **ScrapeCreators, not us** — their `/v1/tiktok/product` endpoint intermittently 500s on products it can otherwise resolve.

**Verified live against thirsty.store** (`VivoNu Himalayan Shilajit Gummies`, id `1731154938869158477`):
- The by-URL endpoint that 500'd in the report now returns **HTTP 200, $35.80** (the correct PDP) on a retry → the failure is a **transient upstream 5xx**.
- Forcing the name-search path returned **$16.90** for a *different* VivoNu listing → name search is a valid fallback but not an exact substitute, so it should be a *last resort*, not the primary path.

## Changes (`core/samples.ts`, `main.ts`)

1. **Retry transient 5xx/429.** `fetchScrapeCreatorsPriceByUrl` previously threw on any non-200. It now goes through a small `fetchWithRetry` (3 attempts, linear backoff) — a retry usually recovers the *correct* PDP price.
2. **Fall back URL → name search.** `fetchScrapeCreatorsPrice` now, for non-`9` ids, tries the by-URL lookup first and falls back to `fetchScrapeCreatorsPriceByName` if it still fails or yields no price — the same endpoint `9`-prefixed ids and the UPC lookup already rely on.
3. **Clean error on the route.** `/api/unpriced-samples/:id/fetch-price` now has a try/catch returning `{ ok:false, error }` `502`, matching its siblings `/api/product-lookup` and `/api/upc-lookup`. `static/ui.js`'s `json()` helper surfaces `data.error`, so a true miss shows a short notice instead of a stack trace — and with retry+fallback it rarely fires at all.

## Verification

- `deno check main.ts`: no new errors (the 4 reported — UPC `source` null/undefined ×3, barcode-PNG `Response` ×1 — **pre-exist on `main`** and are unrelated; flagged separately).
- `fetchWithRetry` control flow unit-tested against a local stub: `500,500,200` → succeeds on attempt 3; always-`500` → exhausts 3 then falls back; `200`/`404` → returns immediately (no wasted credits).

## Note
The live deployment is currently behind `main` (stack-trace line numbers don't match HEAD), but the bug is present at HEAD too — merging + redeploying clears the live error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)