### PR TITLE
Add /api/image-lookup + UPC/image cache to control SerpApi cost

### DIFF
--- a/core/cache.ts
+++ b/core/cache.ts
@@ -1,0 +1,122 @@
+// Best-effort TTL cache for the cost-bearing lookups (UPC + image), so the same
+// scanned barcode or product image doesn't re-spend SerpApi / ScrapeCreators
+// credits on every request. Prefers Deno KV -- it persists across instances and
+// restarts on Deno Deploy and expires entries natively via `expireIn` -- and
+// falls back to a process-local Map (manual TTL sweep) when KV is unavailable
+// (older runtimes, or local `deno run` without KV). The cache is purely an
+// optimization: every read/write is wrapped so a cache fault degrades to a live
+// lookup rather than failing the request.
+
+const KV_PREFIX = "lookup-cache";
+
+// Minimal surface of Deno KV we use. Typed locally (rather than via Deno.Kv) so
+// this module compiles without the `deno.unstable` lib -- KV is resolved at
+// runtime and absence is handled gracefully.
+interface KvLike {
+  get<T>(key: unknown[]): Promise<{ value: T | null }>;
+  set(
+    key: unknown[],
+    value: unknown,
+    opts?: { expireIn?: number },
+  ): Promise<unknown>;
+}
+const denoOpenKv =
+  (Deno as unknown as { openKv?: () => Promise<KvLike> }).openKv;
+
+// One shared KV handle, opened lazily. Resolves to null when KV isn't available
+// so callers transparently fall back to the in-memory map.
+let kvPromise: Promise<KvLike | null> | null = null;
+function openKv(): Promise<KvLike | null> {
+  if (kvPromise) return kvPromise;
+  kvPromise = (async () => {
+    try {
+      if (typeof denoOpenKv !== "function") return null;
+      return await denoOpenKv();
+    } catch {
+      return null; // no KV (e.g. missing --unstable-kv) -> use the memory map
+    }
+  })();
+  return kvPromise;
+}
+
+// Process-local fallback store. Bounded so a long-running instance with KV
+// disabled can't grow it without limit; oldest-inserted entries are evicted.
+type MemEntry = { value: unknown; expiresAt: number };
+const mem = new Map<string, MemEntry>();
+const MEM_MAX_ENTRIES = 1000;
+
+function memKey(namespace: string, key: string): string {
+  return JSON.stringify([namespace, key]);
+}
+
+function memGet(namespace: string, key: string): unknown {
+  const k = memKey(namespace, key);
+  const hit = mem.get(k);
+  if (!hit) return null;
+  if (hit.expiresAt <= Date.now()) {
+    mem.delete(k);
+    return null;
+  }
+  return hit.value;
+}
+
+function memSet(namespace: string, key: string, value: unknown, ttlMs: number) {
+  const k = memKey(namespace, key);
+  // Refresh insertion order on overwrite so the eviction below stays FIFO.
+  mem.delete(k);
+  mem.set(k, { value, expiresAt: Date.now() + ttlMs });
+  while (mem.size > MEM_MAX_ENTRIES) {
+    const oldest = mem.keys().next().value;
+    if (oldest === undefined) break;
+    mem.delete(oldest);
+  }
+}
+
+// Return the cached value for (namespace, key), or null on a miss / any fault.
+export async function cacheGet<T>(
+  namespace: string,
+  key: string,
+): Promise<T | null> {
+  const kv = await openKv();
+  if (kv) {
+    try {
+      const res = await kv.get<T>([KV_PREFIX, namespace, key]);
+      // KV honors `expireIn`, so a present value is still live.
+      return res.value ?? null;
+    } catch {
+      // fall through to the memory map
+    }
+  }
+  return (memGet(namespace, key) as T | null) ?? null;
+}
+
+// Cache `value` under (namespace, key) for ttlMs. Best-effort: a KV failure
+// (e.g. value over the 64 KiB limit) silently falls back to the memory map.
+export async function cacheSet(
+  namespace: string,
+  key: string,
+  value: unknown,
+  ttlMs: number,
+): Promise<void> {
+  if (!(ttlMs > 0)) return;
+  const kv = await openKv();
+  if (kv) {
+    try {
+      await kv.set([KV_PREFIX, namespace, key], value, { expireIn: ttlMs });
+      return;
+    } catch {
+      // fall through to the memory map
+    }
+  }
+  memSet(namespace, key, value, ttlMs);
+}
+
+// Stable, length-bounded cache key for arbitrary strings (e.g. image URLs that
+// can exceed KV's per-key-part size limit). SHA-256 hex of the input.
+export async function hashKey(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/core/cache_test.ts
+++ b/core/cache_test.ts
@@ -1,0 +1,24 @@
+import { expect } from "@std/expect";
+import { cacheGet, cacheSet, hashKey } from "./cache.ts";
+
+Deno.test("hashKey is deterministic and 64 lowercase hex chars", async () => {
+  const a = await hashKey("https://example.com/x.jpg");
+  const b = await hashKey("https://example.com/x.jpg");
+  const c = await hashKey("https://example.com/y.jpg");
+  expect(a).toBe(b);
+  expect(a).not.toBe(c);
+  expect(/^[0-9a-f]{64}$/.test(a)).toBe(true);
+});
+
+Deno.test("cacheSet/cacheGet roundtrips a value and misses on unknown keys", async () => {
+  const key = "k-" + crypto.randomUUID();
+  expect(await cacheGet("test", key)).toBeNull();
+  await cacheSet("test", key, { hello: "world", n: 1 }, 60_000);
+  expect(await cacheGet("test", key)).toEqual({ hello: "world", n: 1 });
+});
+
+Deno.test("cacheSet with a non-positive ttl is a no-op", async () => {
+  const key = "k-" + crypto.randomUUID();
+  await cacheSet("test", key, { x: 1 }, 0);
+  expect(await cacheGet("test", key)).toBeNull();
+});

--- a/core/image_lookup_test.ts
+++ b/core/image_lookup_test.ts
@@ -1,0 +1,184 @@
+import { expect } from "@std/expect";
+import { lookupProductByImage } from "./samples.ts";
+
+// SerpApi Google Lens returns two listings for the same product; the second
+// already-clean title dedups against the first once retail noise is stripped.
+const LENS_BODY = {
+  search_metadata: { status: "Success" },
+  products: [
+    { title: "Acme Widget Pro - Walmart.com", link: "https://walmart.com/x" },
+    { title: "Acme Widget Pro", link: "https://amazon.com/y" },
+  ],
+};
+
+// ScrapeCreators shop/search hit for "Acme Widget Pro".
+const SEARCH_BODY = {
+  products: [
+    {
+      title: "Acme Widget Pro",
+      price: 24.99,
+      url: "https://www.tiktok.com/shop/pdp/acme-widget-pro/1234567890",
+      shop_name: "Acme Shop",
+      cover: "https://img.example.com/widget.jpg",
+    },
+  ],
+};
+
+type Counter = { lens: number; search: number };
+
+function installFetch(counter: Counter) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const u = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    if (u.includes("serpapi.com") && u.includes("engine=google_lens")) {
+      counter.lens++;
+      return Promise.resolve(jsonResponse(LENS_BODY));
+    }
+    if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+      counter.search++;
+      return Promise.resolve(jsonResponse(SEARCH_BODY));
+    }
+    return Promise.resolve(new Response("unexpected", { status: 404 }));
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function withKeys(fn: () => Promise<void>): Promise<void> {
+  const prevSerp = Deno.env.get("SERPAPI_API_KEY");
+  const prevSc = Deno.env.get("SCRAPECREATORS_API_KEY");
+  Deno.env.set("SERPAPI_API_KEY", "test-serp");
+  Deno.env.set("SCRAPECREATORS_API_KEY", "test-sc");
+  return fn().finally(() => {
+    if (prevSerp === undefined) Deno.env.delete("SERPAPI_API_KEY");
+    else Deno.env.set("SERPAPI_API_KEY", prevSerp);
+    if (prevSc === undefined) Deno.env.delete("SCRAPECREATORS_API_KEY");
+    else Deno.env.set("SCRAPECREATORS_API_KEY", prevSc);
+  });
+}
+
+Deno.test("image lookup is gated on SERPAPI_API_KEY", async () => {
+  const prev = Deno.env.get("SERPAPI_API_KEY");
+  Deno.env.delete("SERPAPI_API_KEY");
+  try {
+    const result = await lookupProductByImage("https://img.example.com/a.jpg");
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/SERPAPI_API_KEY/);
+  } finally {
+    if (prev !== undefined) Deno.env.set("SERPAPI_API_KEY", prev);
+  }
+});
+
+Deno.test("image lookup resolves Lens candidates to a TikTok match", async () => {
+  await withKeys(async () => {
+    const counter: Counter = { lens: 0, search: 0 };
+    const restore = installFetch(counter);
+    try {
+      // Unique URL so a persisted KV cache from a prior run can't pre-answer.
+      const imageUrl = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const result = await lookupProductByImage(imageUrl);
+
+      expect(result.ok).toBe(true);
+      expect(result.imageUrl).toBe(imageUrl);
+      expect(result.source).toBe("googlelens");
+      expect(result.candidates).toEqual(["Acme Widget Pro"]);
+      expect(result.item?.title).toBe("Acme Widget Pro");
+      expect(result.match?.productId).toBe("1234567890");
+      expect(result.match?.name).toBe("Acme Widget Pro");
+      expect(result.match?.price).toBe(24.99);
+      expect(result.match?.seller).toBe("Acme Shop");
+      expect(result.debug).toBeUndefined();
+      expect(counter.lens).toBe(1);
+      expect(counter.search).toBe(1);
+
+      // Second non-debug call for the same image is served from cache.
+      const again = await lookupProductByImage(imageUrl);
+      expect(again.match?.productId).toBe("1234567890");
+      expect(counter.lens).toBe(1);
+      expect(counter.search).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("a transient ScrapeCreators failure is not pinned at the positive TTL", async () => {
+  await withKeys(async () => {
+    // Disable negative-TTL caching so a transient failure isn't cached at all;
+    // the next call must re-run and self-heal. Without the errored->negTTL fix,
+    // the ok:true/match:null result would be cached at the long positive TTL and
+    // the second call would serve match:null from cache.
+    const prevNeg = Deno.env.get("LOOKUP_CACHE_NEG_TTL_MS");
+    const prevPos = Deno.env.get("LOOKUP_CACHE_TTL_MS");
+    Deno.env.set("LOOKUP_CACHE_NEG_TTL_MS", "0");
+    Deno.env.set("LOOKUP_CACHE_TTL_MS", "3600000");
+    const realFetch = globalThis.fetch;
+    let scCalls = 0;
+    globalThis.fetch = ((input: string | URL | Request) => {
+      const u = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+      if (u.includes("serpapi.com") && u.includes("engine=google_lens")) {
+        return Promise.resolve(jsonResponse(LENS_BODY));
+      }
+      if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+        scCalls++;
+        // First call: transient 5xx (fetchScrapeCreatorsPriceByName throws,
+        // swallowed as a null match). Second call: recovered.
+        if (scCalls === 1) {
+          return Promise.resolve(new Response("upstream", { status: 500 }));
+        }
+        return Promise.resolve(jsonResponse(SEARCH_BODY));
+      }
+      return Promise.resolve(new Response("unexpected", { status: 404 }));
+    }) as typeof fetch;
+    try {
+      const imageUrl = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const first = await lookupProductByImage(imageUrl);
+      expect(first.ok).toBe(true);
+      expect(first.match).toBeNull(); // ScrapeCreators 500 swallowed
+
+      const second = await lookupProductByImage(imageUrl);
+      expect(second.match?.productId).toBe("1234567890"); // re-ran, self-healed
+      expect(scCalls).toBe(2);
+    } finally {
+      globalThis.fetch = realFetch;
+      if (prevNeg === undefined) Deno.env.delete("LOOKUP_CACHE_NEG_TTL_MS");
+      else Deno.env.set("LOOKUP_CACHE_NEG_TTL_MS", prevNeg);
+      if (prevPos === undefined) Deno.env.delete("LOOKUP_CACHE_TTL_MS");
+      else Deno.env.set("LOOKUP_CACHE_TTL_MS", prevPos);
+    }
+  });
+});
+
+Deno.test("debug echoes the raw Lens payload and bypasses the cache", async () => {
+  await withKeys(async () => {
+    const counter: Counter = { lens: 0, search: 0 };
+    const restore = installFetch(counter);
+    try {
+      const imageUrl = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const first = await lookupProductByImage(imageUrl, { debug: true });
+      expect(first.debug?.[`google_lens:${imageUrl}`]).toEqual(LENS_BODY);
+
+      // A second debug call re-runs Lens (cache bypassed), not served from cache.
+      await lookupProductByImage(imageUrl, { debug: true });
+      expect(counter.lens).toBe(2);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -9,6 +9,7 @@ import {
   type SampleValuation,
   sendGelfMessage,
 } from "./graylog.ts";
+import { cacheGet, cacheSet, hashKey } from "./cache.ts";
 
 export type SamplePriceEdit = {
   productId: string;
@@ -499,6 +500,28 @@ const DEFAULT_OPENFOODFACTS_URL = "https://world.openfoodfacts.org/api/v2/produc
 // match it against Google's shopping graph. Keyed (SERPAPI_API_KEY).
 const DEFAULT_SERPAPI_URL = "https://serpapi.com/search.json";
 
+// Google Lens "type" for the image-lookup endpoint. `products` returns
+// product-oriented matches (names + store links); `exact_matches` is the
+// strictest (only confirmed same-product listings). Overridable via
+// SERPAPI_LENS_TYPE. We parse exact_matches / products / visual_matches from the
+// response regardless, so this just steers which set SerpApi prioritizes.
+const DEFAULT_LENS_TYPE = "products";
+
+// Cache TTLs (ms) for the cost-bearing lookups. Hits live a day by default
+// (a UPC/image → product mapping is stable; only the price drifts), misses an
+// hour (so a transient gap re-checks sooner). Both env-tunable. Parsed
+// explicitly (not `Number(...) || default`) so an operator can set "0" to
+// disable caching — cacheSet treats ttl<=0 as a no-op — while only an unset or
+// non-numeric value falls back to the default.
+function lookupCacheTtl(): number {
+  const n = Number(envValue("LOOKUP_CACHE_TTL_MS"));
+  return Number.isFinite(n) ? n : 24 * 60 * 60 * 1000;
+}
+function lookupCacheNegTtl(): number {
+  const n = Number(envValue("LOOKUP_CACHE_NEG_TTL_MS"));
+  return Number.isFinite(n) ? n : 60 * 60 * 1000;
+}
+
 export type UpcItem = {
   title: string;
   brand: string | null;
@@ -543,6 +566,26 @@ export type UpcLookup = {
 
 // Raw provider responses captured for diagnostics, keyed by "engine:query".
 export type SerpDebug = Record<string, unknown>;
+
+// Result of resolving a product *image* (not a barcode) to a TikTok Shop
+// product: SerpApi Google Lens turns the image into candidate product names,
+// then ScrapeCreators resolves the best candidate to a live listing. Mirrors
+// UpcLookup so the tracker can share rendering, keyed by imageUrl instead of upc.
+export type ImageLookup = {
+  ok: boolean;
+  imageUrl: string;
+  // Best candidate Lens surfaced (its title drives the TikTok search).
+  item?: UpcItem;
+  // Every candidate title Lens returned, best-first — diagnostic context for the
+  // debug panel even when none resolved to a TikTok product.
+  candidates?: string[];
+  match?: UpcMatch | null;
+  error?: string;
+  // Which Lens result set answered ("googlelens" — products/exact/visual).
+  source?: "googlelens";
+  // Raw SerpApi payload when the caller asks for debug (?debug=1).
+  debug?: SerpDebug;
+};
 
 // UPCitemdb: trial endpoint needs no key (rate-limited ~100/day, shared). A paid
 // plan key (UPCITEMDB_API_KEY) switches to the authenticated endpoint headers.
@@ -705,6 +748,56 @@ async function fetchGoogleLensItem(
   return null;
 }
 
+// A product candidate Lens returned for an image: the cleaned listing title
+// (drives the TikTok search) and its source link (diagnostic).
+type LensCandidate = { title: string; link: string | null };
+
+// Google Lens via SerpApi, pointed at a *product image* (the image-lookup
+// endpoint). Unlike the barcode fallback above, this matches the photo itself —
+// SerpApi's `google searches by image` behavior — and returns product-oriented
+// candidates. We request the configured type (products / exact_matches) but
+// parse every result set the response carries, most-precise first, so the caller
+// gets candidate names even when SerpApi files them under a different key.
+async function fetchGoogleLensProducts(
+  imageUrl: string,
+  key: string,
+  debug?: SerpDebug,
+): Promise<LensCandidate[]> {
+  const url = new URL(envValue("SERPAPI_API_URL") || DEFAULT_SERPAPI_URL);
+  url.searchParams.set("engine", "google_lens");
+  url.searchParams.set("url", imageUrl);
+  url.searchParams.set("type", envValue("SERPAPI_LENS_TYPE") || DEFAULT_LENS_TYPE);
+  url.searchParams.set("api_key", key);
+
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(`Google Lens lookup failed: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  if (debug) debug[`google_lens:${imageUrl}`] = body;
+
+  // Exact matches are confirmed same-product listings; products / visual matches
+  // are progressively looser. Walk them in that order and dedup by cleaned title.
+  const groups = ["exact_matches", "products", "product_results", "visual_matches"];
+  const seen = new Set<string>();
+  const out: LensCandidate[] = [];
+  if (isRecord(body)) {
+    for (const groupKey of groups) {
+      const arr = Array.isArray(body[groupKey]) ? body[groupKey] as unknown[] : [];
+      for (const entry of arr) {
+        if (!isRecord(entry) || !entry.title) continue;
+        const title = cleanLensTitle(String(entry.title));
+        if (!title) continue;
+        const dedup = title.toLowerCase();
+        if (seen.has(dedup)) continue;
+        seen.add(dedup);
+        out.push({ title, link: entry.link ? String(entry.link) : null });
+      }
+    }
+  }
+  return out;
+}
+
 // Google Shopping via SerpApi. Shopping listings are indexed by GTIN/UPC, so a
 // raw barcode query often surfaces the exact product even when plain web search
 // (and Lens visual matching) come up empty — the more reliable of the two
@@ -860,53 +953,18 @@ function productIdFromUrl(sourceUrl: string | undefined): string | null {
   return m ? m[1] : null;
 }
 
-// `origin` is the request's public origin, used to build the barcode-image URL
-// for the Google Lens fallback. PUBLIC_BASE_URL overrides it when the request
-// origin isn't externally reachable (e.g. behind an internal proxy). `debug`
-// echoes the raw SerpApi payloads back to the caller for diagnostics.
-export async function lookupProductByUpc(
-  upc: string,
-  opts: { origin?: string; debug?: boolean } = {},
-): Promise<UpcLookup> {
-  const clean = String(upc || "").replace(/\D/g, "");
-  if (!clean) throw new Error("upc is required");
-
-  const publicBase = envValue("PUBLIC_BASE_URL") || opts.origin || "";
-  const { item, source, providersTried, debug } = await fetchUpcItem(
-    clean,
-    publicBase,
-    opts.debug,
-  );
-  if (!item) {
-    return {
-      ok: false,
-      upc: clean,
-      error: "No product found for that UPC",
-      providersTried,
-      debug,
-    };
-  }
-
-  const apiKey = envValue("SCRAPECREATORS_API_KEY") || envValue("API_KEY");
-  if (!apiKey) {
-    // No TikTok search available — still hand back the resolved item.
-    return { ok: true, upc: clean, upcItem: item, match: null, providersTried, source, debug };
-  }
-
-  // Search TikTok Shop by brand + title (deduped) for the best match.
-  const query = [item.brand, item.title]
-    .filter(Boolean)
-    .join(" ")
-    .replace(/\s+/g, " ")
-    .trim();
-  const product: ProductAnalysis = {
-    productId: "9" + clean, // synthetic id: never a real PDP, forces name search
-    name: query || item.title,
+// The synthetic ProductAnalysis the ScrapeCreators name search needs. Only
+// `name` is read by that search; the "9"-prefixed id forces the name-search path
+// (never a real PDP) and the rest are zero placeholders.
+function syntheticProduct(name: string, idHint = ""): ProductAnalysis {
+  return {
+    productId: "9" + idHint,
+    name,
     priceRange: "",
     min_sku_original_price: 0,
-    category: item.category || "",
+    category: "",
     categoryRank: null,
-    seller: item.brand || "",
+    seller: "",
     creators: 0,
     liveStreams: 0,
     videos: 0,
@@ -921,6 +979,24 @@ export async function lookupProductByUpc(
     lastSeen: null,
     image: null,
   };
+}
+
+// Resolve a free-text product name to the best matching TikTok Shop listing via
+// ScrapeCreators. Shared by the UPC and image lookups. Never throws — a price
+// miss must not fail the whole lookup. Returns { match, errored }: `errored` is
+// true only when the ScrapeCreators call itself failed transiently
+// (network/5xx/429/credit), distinct from a clean "no listing" miss, so the
+// caller can cache a transient failure briefly instead of for the full positive
+// TTL. `idHint` only labels the synthetic id; the real product id comes from the
+// matched listing's URL.
+async function resolveTiktokMatchByName(
+  name: string,
+  idHint = "",
+): Promise<{ match: UpcMatch | null; errored: boolean }> {
+  const apiKey = envValue("SCRAPECREATORS_API_KEY") || envValue("API_KEY");
+  if (!apiKey) return { match: null, errored: false };
+  const trimmed = name.replace(/\s+/g, " ").trim();
+  if (!trimmed) return { match: null, errored: false };
 
   const base = (envValue("SCRAPECREATORS_API_BASE") || DEFAULT_SCRAPECREATORS_BASE)
     .replace(/\/+$/, "");
@@ -928,22 +1004,18 @@ export async function lookupProductByUpc(
 
   let lookup: ScrapeCreatorsPrice | null = null;
   try {
-    lookup = await fetchScrapeCreatorsPriceByName(base, apiKey, region, product);
+    lookup = await fetchScrapeCreatorsPriceByName(
+      base,
+      apiKey,
+      region,
+      syntheticProduct(trimmed, idHint),
+    );
   } catch {
-    lookup = null; // a search miss/credit error shouldn't fail the whole lookup
+    return { match: null, errored: true }; // transient — don't cache long
   }
-
-  if (!lookup || !lookup.title) {
-    return { ok: true, upc: clean, upcItem: item, match: null, providersTried, source, debug };
-  }
+  if (!lookup || !lookup.title) return { match: null, errored: false };
 
   return {
-    ok: true,
-    upc: clean,
-    upcItem: item,
-    providersTried,
-    source,
-    debug,
     match: {
       productId: productIdFromUrl(lookup.sourceUrl),
       name: lookup.title || null,
@@ -953,6 +1025,172 @@ export async function lookupProductByUpc(
       sourceUrl: lookup.sourceUrl || null,
       product: lookup.product,
     },
+    errored: false,
+  };
+}
+
+// `origin` is the request's public origin, used to build the barcode-image URL
+// for the Google Lens fallback. PUBLIC_BASE_URL overrides it when the request
+// origin isn't externally reachable (e.g. behind an internal proxy). `debug`
+// echoes the raw SerpApi payloads back to the caller for diagnostics — and
+// bypasses the cache, so a debug call always returns fresh raw payloads.
+export async function lookupProductByUpc(
+  upc: string,
+  opts: { origin?: string; debug?: boolean } = {},
+): Promise<UpcLookup> {
+  const clean = String(upc || "").replace(/\D/g, "");
+  if (!clean) throw new Error("upc is required");
+
+  // Cache by UPC to spare repeat scans the provider + SerpApi credits. Skipped
+  // under debug so the raw payloads are always live. Only resolved results are
+  // cached (computeUpcLookup throws on hard provider failure, so those aren't
+  // stored).
+  if (!opts.debug) {
+    const cached = await cacheGet<UpcLookup>("upc", clean);
+    if (cached) return cached;
+  }
+
+  const { lookup, matchErrored } = await computeUpcLookup(clean, opts);
+
+  if (!opts.debug) {
+    // A transient ScrapeCreators failure yields ok:true/match:null; cache it only
+    // briefly (negative TTL) so the price re-checks within the hour once the
+    // provider recovers, rather than pinning a matchless result for the full day.
+    const ttl = matchErrored || !lookup.ok ? lookupCacheNegTtl() : lookupCacheTtl();
+    await cacheSet("upc", clean, lookup, ttl);
+  }
+  return lookup;
+}
+
+async function computeUpcLookup(
+  clean: string,
+  opts: { origin?: string; debug?: boolean },
+): Promise<{ lookup: UpcLookup; matchErrored: boolean }> {
+  const publicBase = envValue("PUBLIC_BASE_URL") || opts.origin || "";
+  const { item, source, providersTried, debug } = await fetchUpcItem(
+    clean,
+    publicBase,
+    opts.debug,
+  );
+  if (!item) {
+    return {
+      lookup: {
+        ok: false,
+        upc: clean,
+        error: "No product found for that UPC",
+        providersTried,
+        debug,
+      },
+      matchErrored: false,
+    };
+  }
+
+  // Search TikTok Shop by brand + title (deduped) for the best match.
+  const query = [item.brand, item.title]
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const { match, errored } = await resolveTiktokMatchByName(
+    query || item.title,
+    clean,
+  );
+
+  return {
+    lookup: {
+      ok: true,
+      upc: clean,
+      upcItem: item,
+      providersTried,
+      source: source ?? undefined,
+      debug,
+      match,
+    },
+    matchErrored: errored,
+  };
+}
+
+// Resolve a product *image* (URL) to a TikTok Shop product: SerpApi Google Lens
+// turns the image into candidate product names, then ScrapeCreators resolves the
+// best candidate to a live listing — the "search by image" path for TikTok
+// metadata/image matching. Gated on SERPAPI_API_KEY. Cached by image URL to
+// control cost; `debug` bypasses the cache and echoes the raw Lens payload.
+export async function lookupProductByImage(
+  imageUrl: string,
+  opts: { debug?: boolean } = {},
+): Promise<ImageLookup> {
+  const url = String(imageUrl || "").trim();
+  if (!url) throw new Error("image url is required");
+
+  const serpApiKey = envValue("SERPAPI_API_KEY");
+  if (!serpApiKey) {
+    return {
+      ok: false,
+      imageUrl: url,
+      error: "image lookup unavailable: SERPAPI_API_KEY is not configured",
+    };
+  }
+
+  const cacheKey = await hashKey(url);
+  if (!opts.debug) {
+    const cached = await cacheGet<ImageLookup>("image", cacheKey);
+    if (cached) return cached;
+  }
+
+  const { lookup, matchErrored } = await computeImageLookup(
+    url,
+    serpApiKey,
+    opts.debug,
+  );
+
+  if (!opts.debug) {
+    // As in lookupProductByUpc: a transient ScrapeCreators failure re-checks
+    // within the hour instead of pinning a matchless result for the full day.
+    const ttl = matchErrored || !lookup.ok ? lookupCacheNegTtl() : lookupCacheTtl();
+    await cacheSet("image", cacheKey, lookup, ttl);
+  }
+  return lookup;
+}
+
+async function computeImageLookup(
+  url: string,
+  serpApiKey: string,
+  debug = false,
+): Promise<{ lookup: ImageLookup; matchErrored: boolean }> {
+  const debugInfo: SerpDebug | undefined = debug ? {} : undefined;
+  const candidates = await fetchGoogleLensProducts(url, serpApiKey, debugInfo);
+  const candidateTitles = candidates.map((c) => c.title);
+
+  if (!candidates.length) {
+    return {
+      lookup: {
+        ok: false,
+        imageUrl: url,
+        error: "No product matches for that image",
+        candidates: candidateTitles,
+        debug: debugInfo,
+      },
+      matchErrored: false,
+    };
+  }
+
+  const best = candidates[0];
+  const item: UpcItem = { title: best.title, brand: null, category: null };
+  // Resolve only the top candidate to a TikTok listing — one ScrapeCreators
+  // search keeps the per-lookup cost bounded.
+  const { match, errored } = await resolveTiktokMatchByName(best.title);
+
+  return {
+    lookup: {
+      ok: true,
+      imageUrl: url,
+      item,
+      candidates: candidateTitles,
+      source: "googlelens",
+      debug: debugInfo,
+      match,
+    },
+    matchErrored: errored,
   };
 }
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,44 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/expect@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.13": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.4": "1.1.5",
     "npm:@tanstack/react-query@^5.12.0": "5.90.12_react@18.3.1",
+    "npm:bwip-js@4": "4.11.1",
     "npm:lucide-react@0.294": "0.294.0_react@18.3.1",
     "npm:pg@*": "8.16.3",
     "npm:react-dom@^18.2.0": "18.3.1_react@18.3.1",
     "npm:react-router-dom@^6.20.0": "6.30.2_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:react@^18.2.0": "18.3.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/expect@1.0.19": {
+      "integrity": "25271785688c7ff902fa54875d6aa4001f552c5578f7f0fefb5b5aac1fc2ed8a",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    }
   },
   "npm": {
     "@remix-run/router@1.23.1": {
@@ -21,6 +53,10 @@
         "@tanstack/query-core",
         "react"
       ]
+    },
+    "bwip-js@4.11.1": {
+      "integrity": "sha512-9KCjsJF/VSETOS6jPgNxd6X9yCHTbqcm2zccDceX7bOmxDDjQ92V9S+iFf+UD5+hijUZDw7SFsYT7vL2rW7qcQ==",
+      "bin": true
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,7 @@ import {
   fetchProductWithEdits,
   fetchSampleValuationWithEdits,
   listUnpricedSamples,
+  lookupProductByImage,
   lookupProductByUpc,
   lookupProductDetails,
   updateSamplePrice,
@@ -86,6 +87,21 @@ function corsJson(data: unknown, status = 200) {
       "content-type": "application/json; charset=utf-8",
       "cache-control": "no-store",
       "access-control-allow-origin": "*",
+    },
+  });
+}
+
+// CORS preflight for the endpoints that accept POST with a JSON body (e.g.
+// /api/image-lookup) — a cross-origin JSON POST triggers an OPTIONS preflight
+// the simple GET endpoints never see.
+function corsPreflight() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET, POST, OPTIONS",
+      "access-control-allow-headers": "content-type",
+      "access-control-max-age": "86400",
     },
   });
 }
@@ -722,6 +738,48 @@ export async function legacyHandler(req: Request): Promise<Response> {
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return corsJson({ ok: false, upc, error: msg }, 502);
+        }
+      }
+
+      // Image lookup for the tracker's "search by image" path: resolve a product
+      // IMAGE (URL) to a TikTok product via SerpApi Google Lens (type=products /
+      // exact_matches) → candidate names → ScrapeCreators. Gated on
+      // SERPAPI_API_KEY, cached by image URL. ?debug=1 echoes the raw Lens
+      // payload (bypassing the cache). Accepts GET ?url= or POST {url}; carries
+      // CORS + an OPTIONS preflight for the cross-origin JSON POST.
+      if (pathname === "/api/image-lookup") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "GET" && req.method !== "POST") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        let imageUrl = url.searchParams.get("url") || url.searchParams.get("image") || "";
+        let debug = url.searchParams.get("debug") === "1";
+        if (req.method === "POST") {
+          const body = await readJsonBody(req);
+          if (!imageUrl && typeof body.url === "string") imageUrl = body.url;
+          if (!imageUrl && typeof body.image === "string") imageUrl = body.image;
+          if (body.debug === true || body.debug === "1" || body.debug === 1) debug = true;
+        }
+        imageUrl = imageUrl.trim();
+        if (!imageUrl) {
+          return corsJson(
+            {
+              ok: false,
+              error: "image url is required (?url= / ?image= or POST {url})",
+            },
+            400,
+          );
+        }
+        try {
+          const result = await lookupProductByImage(imageUrl, { debug });
+          // SERPAPI_API_KEY unset → the feature is unavailable, not a bad request.
+          const status = !result.ok && /SERPAPI_API_KEY/.test(result.error || "")
+            ? 503
+            : 200;
+          return corsJson(result, status);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson({ ok: false, imageUrl, error: msg }, 502);
         }
       }
 


### PR DESCRIPTION
## What

Two additions on top of the existing UPC lookup chain (UPCitemdb → … → SerpApi Google Shopping/Lens → ScrapeCreators):

### 1. `GET|POST /api/image-lookup`
Resolves a product **image URL** to a TikTok Shop product — the "search by image" path for TikTok metadata/image matching:

`image → SerpApi Google Lens (type=products / exact_matches) → candidate names → ScrapeCreators TikTok Shop search → best match`

- Accepts `?url=` / `?image=` (GET) or `{url}` / `{image}` (POST JSON).
- Gated on `SERPAPI_API_KEY` → `503` when unset.
- `?debug=1` echoes the raw Lens payload (keyed `google_lens:<url>`), bypassing the cache.
- Carries CORS `*` and an `OPTIONS` preflight (the cross-origin JSON POST needs it).

### 2. UPC/image cache (`core/cache.ts`)
Best-effort TTL cache so repeat scans don't re-spend SerpApi / ScrapeCreators credits:
- **Deno KV** when available (persists across instances/restarts on Deno Deploy, native `expireIn`), **in-memory Map** fallback otherwise.
- Keyed by UPC and by `sha256(imageUrl)`.
- Hits live 24h, misses 1h (`LOOKUP_CACHE_TTL_MS` / `LOOKUP_CACHE_NEG_TTL_MS`; set `0` to disable).
- **Debug bypasses the cache** so raw payloads are always fresh.
- A transient ScrapeCreators failure caches only briefly (negative TTL) so the price re-checks within the hour instead of being pinned for a day.

### Refactor
Shared `resolveTiktokMatchByName()` backs both lookups; `lookupProductByUpc` is now a thin cache wrapper over `computeUpcLookup` — existing UPC behavior preserved.

## Note: ties in with the tracker
The Google Shopping fallback and `?debug=1` passthrough already existed. The client that exercises debug is wired in tiktok-sample-tracker#44 (the scan-page Debug toggle now sends `?debug=1`).

## Tests
`core/cache_test.ts`, `core/image_lookup_test.ts` (7 tests): cache roundtrip/TTL no-op, SERPAPI gate, Lens→candidates→ScrapeCreators match, debug echo, cache-hit-no-refetch, and a transient-ScrapeCreators-failure self-heal regression. Verified with `deno test -A` + a live HTTP smoke test (400 / 503 / 204-OPTIONS / upc-lookup intact).

## Pre-existing, not addressed here
`deno check main.ts` reports one pre-existing barcode `Uint8Array`→`Response` BodyInit error (TS 5.9 lib drift, present on `main`). Spun off as a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)