### PR TITLE
Fix deno check: type renderBarcodePng as Uint8Array<ArrayBuffer>

### DIFF
--- a/core/barcode.ts
+++ b/core/barcode.ts
@@ -4,7 +4,7 @@ import bwipjs from "npm:bwip-js@^4";
 // digit count — EAN-13 (13), UPC-A (12) — falling back to Code 128 so any
 // scanned string still produces a scannable image. Exists so the UPC lookup's
 // Google Lens fallback has a public image of the barcode to visually match.
-export async function renderBarcodePng(code: string): Promise<Uint8Array> {
+export async function renderBarcodePng(code: string): Promise<Uint8Array<ArrayBuffer>> {
   const digits = code.replace(/\D/g, "");
   let bcid = "code128";
   let text = code;


### PR DESCRIPTION
## Problem

`deno check main.ts` failed under Deno 2.7 / TypeScript 5.9:

```
TS2345 [ERROR]: Argument of type 'Uint8Array<ArrayBufferLike>' is not
assignable to parameter of type 'BodyInit | null | undefined'.
          return new Response(png, { ... })   // /api/barcode/<upc>.png handler in main.ts
```

TS 5.9's DOM lib made typed arrays generic (`Uint8Array<ArrayBufferLike>`), and `BodyInit`/`BufferSource` now expect an `ArrayBuffer`-backed view. `renderBarcodePng()` returned a plain `Uint8Array`, so this was a type-level mismatch only — no runtime bug.

## Fix

Typed the value at its origin: `renderBarcodePng()` in [core/barcode.ts](core/barcode.ts) now returns `Uint8Array<ArrayBuffer>`. Its result is built with `new Uint8Array(...)`, which is genuinely `ArrayBuffer`-backed, so the declaration is accurate and every call site (including the `new Response(png, ...)` in [main.ts](main.ts)) typechecks cleanly. No call-site casts needed.

## Verify

- `deno check main.ts` → 0 errors
- `deno task check` → passes

The 3 `TS2322` `UpcSource | null` errors mentioned in the task were resolved by [data-pimp#66](https://github.com/easierbycode/data-pimp/pull/66), which is already merged into `main` — so `deno check main.ts` is fully clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)