### PR TITLE
Add /api/lens-lookup — Google Lens image search returning ranked candidates

### DIFF
--- a/core/lens_lookup_test.ts
+++ b/core/lens_lookup_test.ts
@@ -1,0 +1,244 @@
+import { expect } from "@std/expect";
+import { lookupProductByLens } from "./samples.ts";
+
+// SerpApi Google Lens returns visual matches across result sets, best-first.
+// "Acme Widget Pro" and "...Pro XL" both resolve to the same TikTok listing (so
+// they de-dupe to one "tiktok" candidate); "Acme Widget Mini" misses and stays a
+// "google_lens" candidate carrying the Lens-supplied image/price/seller.
+const LENS_BODY = {
+  search_metadata: { status: "Success" },
+  exact_matches: [
+    {
+      title: "Acme Widget Pro - Walmart.com",
+      link: "https://walmart.com/x",
+      thumbnail: "https://img.example.com/walmart.jpg",
+      source: "Walmart",
+      price: { value: "$24.99", extracted_value: 24.99, currency: "$" },
+    },
+  ],
+  visual_matches: [
+    {
+      title: "Acme Widget Pro XL",
+      link: "https://amazon.com/xl",
+      thumbnail: "https://img.example.com/xl.jpg",
+      source: "Amazon",
+      price: 27.5,
+    },
+    {
+      title: "Acme Widget Mini",
+      link: "https://amazon.com/mini",
+      thumbnail: "https://img.example.com/mini.jpg",
+      source: "Amazon",
+      price: 12.5,
+    },
+  ],
+};
+
+// ScrapeCreators shop/search hit for the "Widget Pro" queries.
+const SEARCH_BODY = {
+  products: [
+    {
+      title: "Acme Widget Pro",
+      price: 24.99,
+      url: "https://www.tiktok.com/shop/pdp/acme-widget-pro/1234567890",
+      shop_name: "Acme Shop",
+      cover: "https://img.example.com/widget.jpg",
+    },
+  ],
+};
+
+type Counter = { lens: number; search: number };
+
+// Resolve "Widget Pro"/"...Pro XL" to the TikTok listing; everything else is a
+// clean miss (empty products → null match → google_lens fallback).
+function installFetch(counter: Counter) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const u = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    if (u.includes("serpapi.com") && u.includes("engine=google_lens")) {
+      counter.lens++;
+      return Promise.resolve(jsonResponse(LENS_BODY));
+    }
+    if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+      counter.search++;
+      const query = new URL(u).searchParams.get("query")?.toLowerCase() || "";
+      if (query.includes("widget pro")) {
+        return Promise.resolve(jsonResponse(SEARCH_BODY));
+      }
+      return Promise.resolve(jsonResponse({ products: [] }));
+    }
+    return Promise.resolve(new Response("unexpected", { status: 404 }));
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function withKeys(fn: () => Promise<void>): Promise<void> {
+  const prevSerp = Deno.env.get("SERPAPI_API_KEY");
+  const prevSc = Deno.env.get("SCRAPECREATORS_API_KEY");
+  Deno.env.set("SERPAPI_API_KEY", "test-serp");
+  Deno.env.set("SCRAPECREATORS_API_KEY", "test-sc");
+  return fn().finally(() => {
+    if (prevSerp === undefined) Deno.env.delete("SERPAPI_API_KEY");
+    else Deno.env.set("SERPAPI_API_KEY", prevSerp);
+    if (prevSc === undefined) Deno.env.delete("SCRAPECREATORS_API_KEY");
+    else Deno.env.set("SCRAPECREATORS_API_KEY", prevSc);
+  });
+}
+
+Deno.test("lens lookup is gated on SERPAPI_API_KEY", async () => {
+  const prev = Deno.env.get("SERPAPI_API_KEY");
+  Deno.env.delete("SERPAPI_API_KEY");
+  try {
+    const result = await lookupProductByLens("https://img.example.com/a.jpg");
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/SERPAPI_API_KEY/);
+    expect(result.image).toBe("https://img.example.com/a.jpg");
+  } finally {
+    if (prev !== undefined) Deno.env.set("SERPAPI_API_KEY", prev);
+  }
+});
+
+Deno.test("lens lookup ranks UpcMatch candidates, boosting TikTok hits", async () => {
+  await withKeys(async () => {
+    const counter: Counter = { lens: 0, search: 0 };
+    const restore = installFetch(counter);
+    try {
+      // Unique URL so a persisted KV cache from a prior run can't pre-answer.
+      const image = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const result = await lookupProductByLens(image);
+
+      expect(result.ok).toBe(true);
+      expect(result.image).toBe(image);
+      expect(result.source).toBe("googlelens");
+
+      // Two "Widget Pro" titles collapse to one TikTok listing; the Mini miss
+      // stays a google_lens candidate. TikTok ranks first; match == [0].
+      const candidates = result.candidates ?? [];
+      expect(candidates.length).toBe(2);
+      expect(result.match).toEqual(candidates[0]);
+
+      const top = candidates[0];
+      expect(top.source).toBe("tiktok");
+      expect(top.productId).toBe("1234567890");
+      expect(top.name).toBe("Acme Widget Pro");
+      expect(top.price).toBe(24.99);
+      expect(top.seller).toBe("Acme Shop");
+
+      const second = candidates[1];
+      expect(second.source).toBe("google_lens");
+      expect(second.name).toBe("Acme Widget Mini");
+      expect(second.price).toBe(12.5); // numeric, from the Lens payload
+      expect(second.seller).toBe("Amazon");
+      expect(second.sourceUrl).toBe("https://amazon.com/mini");
+      expect(second.productId).toBeNull(); // not a TikTok link
+
+      // All three Lens candidates were resolved (within the default cap of 5).
+      expect(counter.lens).toBe(1);
+      expect(counter.search).toBe(3);
+      expect(result.debug).toBeUndefined();
+
+      // Second non-debug call for the same image is served from cache.
+      const again = await lookupProductByLens(image);
+      expect(again.match?.productId).toBe("1234567890");
+      expect(counter.lens).toBe(1);
+      expect(counter.search).toBe(3);
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("lens lookup returns google_lens candidates when nothing resolves to TikTok", async () => {
+  await withKeys(async () => {
+    const realFetch = globalThis.fetch;
+    // Lens hits, but ScrapeCreators always misses (empty products).
+    globalThis.fetch = ((input: string | URL | Request) => {
+      const u = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+      if (u.includes("serpapi.com") && u.includes("engine=google_lens")) {
+        return Promise.resolve(jsonResponse(LENS_BODY));
+      }
+      if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+        return Promise.resolve(jsonResponse({ products: [] }));
+      }
+      return Promise.resolve(new Response("unexpected", { status: 404 }));
+    }) as typeof fetch;
+    try {
+      const image = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const result = await lookupProductByLens(image);
+
+      expect(result.ok).toBe(true);
+      const candidates = result.candidates ?? [];
+      expect(candidates.length).toBe(3); // all distinct titles survive
+      expect(candidates.every((c) => c.source === "google_lens")).toBe(true);
+      expect(result.match).toEqual(candidates[0]);
+      expect(candidates[0].name).toBe("Acme Widget Pro");
+      expect(candidates[0].price).toBe(24.99); // parsed from { extracted_value }
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+Deno.test("lens lookup reports no matches for an image Lens can't place", async () => {
+  await withKeys(async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: string | URL | Request) => {
+      const u = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+      if (u.includes("serpapi.com") && u.includes("engine=google_lens")) {
+        return Promise.resolve(
+          jsonResponse({ search_metadata: { status: "Success" } }),
+        );
+      }
+      return Promise.resolve(new Response("unexpected", { status: 404 }));
+    }) as typeof fetch;
+    try {
+      const image = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const result = await lookupProductByLens(image);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/No product matches/);
+      expect(result.candidates).toEqual([]);
+      expect(result.match ?? null).toBeNull();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+Deno.test("lens debug echoes the raw Lens payload and bypasses the cache", async () => {
+  await withKeys(async () => {
+    const counter: Counter = { lens: 0, search: 0 };
+    const restore = installFetch(counter);
+    try {
+      const image = `https://img.example.com/${crypto.randomUUID()}.jpg`;
+      const first = await lookupProductByLens(image, { debug: true });
+      expect(first.debug?.[`google_lens:${image}`]).toEqual(LENS_BODY);
+
+      // A second debug call re-runs Lens (cache bypassed), not served from cache.
+      await lookupProductByLens(image, { debug: true });
+      expect(counter.lens).toBe(2);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -535,6 +535,11 @@ export type UpcMatch = {
   image: string | null;
   seller: string | null;
   sourceUrl: string | null;
+  // Where this match came from: "tiktok" once a candidate resolves to a TikTok
+  // Shop listing (via ScrapeCreators), "google_lens" for a raw Lens visual
+  // match that didn't. Lets the lens-lookup endpoint rank in-platform listings
+  // above visual-only matches and tag each candidate's provenance.
+  source?: string | null;
   product?: Record<string, unknown>;
 };
 
@@ -582,6 +587,23 @@ export type ImageLookup = {
   match?: UpcMatch | null;
   error?: string;
   // Which Lens result set answered ("googlelens" — products/exact/visual).
+  source?: "googlelens";
+  // Raw SerpApi payload when the caller asks for debug (?debug=1).
+  debug?: SerpDebug;
+};
+
+// Result of the /api/lens-lookup endpoint: the same Google Lens search as
+// ImageLookup, but every visual match mapped to the shared UpcMatch shape and
+// ranked best-first (TikTok-resolved listings boosted above raw Lens matches) —
+// the candidate shape /api/upc-lookup returns. Backs the inventory app's "Find
+// by photo" flow. Keyed by `image` (the response echoes it under that name).
+export type LensLookup = {
+  ok: boolean;
+  image: string;
+  // Ranked candidates, best-first; match is candidates[0] (null when none).
+  match?: UpcMatch | null;
+  candidates?: UpcMatch[];
+  error?: string;
   source?: "googlelens";
   // Raw SerpApi payload when the caller asks for debug (?debug=1).
   debug?: SerpDebug;
@@ -749,8 +771,36 @@ async function fetchGoogleLensItem(
 }
 
 // A product candidate Lens returned for an image: the cleaned listing title
-// (drives the TikTok search) and its source link (diagnostic).
-type LensCandidate = { title: string; link: string | null };
+// (drives the TikTok search) plus the fields needed to map it straight to a
+// UpcMatch (image-lookup only reads `title`; lens-lookup uses the rest to render
+// a "google_lens" candidate when it doesn't resolve to a TikTok listing).
+type LensCandidate = {
+  title: string;
+  link: string | null;
+  image: string | null;
+  price: number;
+  seller: string | null;
+};
+
+// Pull a numeric price out of a Lens visual match. SerpApi reports it as
+// { value: "$19.99", extracted_value: 19.99, currency: "$" }, but older shapes
+// use a bare number or string — handle all three, returning 0 (unknown) when no
+// parseable amount is present.
+function lensEntryPrice(entry: Record<string, unknown>): number {
+  const p = entry.price;
+  if (typeof p === "number") return Number.isFinite(p) ? p : 0;
+  const fromString = (s: string): number => {
+    const n = Number(s.replace(/[^0-9.]/g, ""));
+    return Number.isFinite(n) ? n : 0;
+  };
+  if (typeof p === "string") return fromString(p);
+  if (isRecord(p)) {
+    const ev = p.extracted_value;
+    if (typeof ev === "number" && Number.isFinite(ev)) return ev;
+    if (typeof p.value === "string") return fromString(p.value);
+  }
+  return 0;
+}
 
 // Google Lens via SerpApi, pointed at a *product image* (the image-lookup
 // endpoint). Unlike the barcode fallback above, this matches the photo itself —
@@ -791,7 +841,24 @@ async function fetchGoogleLensProducts(
         const dedup = title.toLowerCase();
         if (seen.has(dedup)) continue;
         seen.add(dedup);
-        out.push({ title, link: entry.link ? String(entry.link) : null });
+        const image = entry.thumbnail
+          ? String(entry.thumbnail)
+          : entry.image
+          ? String(entry.image)
+          : null;
+        out.push({
+          title,
+          link: entry.link ? String(entry.link) : null,
+          image,
+          price: lensEntryPrice(entry),
+          // Lens labels the storefront in `source` (e.g. "Walmart"); fall back
+          // to `source_name` for the visual_matches shape.
+          seller: entry.source
+            ? String(entry.source)
+            : entry.source_name
+            ? String(entry.source_name)
+            : null,
+        });
       }
     }
   }
@@ -1023,6 +1090,7 @@ async function resolveTiktokMatchByName(
       image: lookup.image ?? null,
       seller: lookup.seller ?? null,
       sourceUrl: lookup.sourceUrl || null,
+      source: "tiktok",
       product: lookup.product,
     },
     errored: false,
@@ -1191,6 +1259,160 @@ async function computeImageLookup(
       match,
     },
     matchErrored: errored,
+  };
+}
+
+// How many of the (best-first) Lens candidates the lens-lookup endpoint resolves
+// against ScrapeCreators to find a TikTok listing. Each is a ScrapeCreators
+// credit, so it's bounded (and env-tunable) — the rest stay "google_lens"
+// candidates. Parsed explicitly so an operator can set "0" to disable the TikTok
+// upgrade entirely while an unset/non-numeric value falls back to the default.
+function lensTiktokResolveCap(): number {
+  const n = Number(envValue("LENS_TIKTOK_RESOLVE_CAP"));
+  return Number.isFinite(n) && n >= 0 ? n : 5;
+}
+
+// Map a raw Lens visual match to a "google_lens"-tagged UpcMatch — the candidate
+// we surface when it didn't resolve to a TikTok listing. productId is only set
+// for an actual TikTok Shop link (productIdFromUrl matches any digit run, which
+// would be noise on a Walmart/Amazon URL).
+function lensCandidateToMatch(c: LensCandidate): UpcMatch {
+  const link = c.link ?? null;
+  const isTikTok = !!link && /tiktok\.com/i.test(link);
+  return {
+    productId: isTikTok ? productIdFromUrl(link) : null,
+    name: c.title || null,
+    price: c.price || 0,
+    image: c.image ?? null,
+    seller: c.seller ?? null,
+    sourceUrl: link,
+    source: "google_lens",
+  };
+}
+
+// Stable identity for de-duping a UpcMatch list: prefer the TikTok product id,
+// then the source URL, then the (lowercased) name — so the same listing reached
+// two ways (e.g. two Lens titles resolving to one TikTok product) collapses.
+function matchDedupeKey(m: UpcMatch): string {
+  if (m.productId) return `id:${m.productId}`;
+  if (m.sourceUrl) return `url:${m.sourceUrl.toLowerCase()}`;
+  return `name:${(m.name || "").toLowerCase()}`;
+}
+
+// De-dupe and rank a UpcMatch list best-first: TikTok-resolved listings (richer,
+// in-platform) ahead of raw Lens visual matches, each group preserving its
+// upstream (Lens best-first) order. Capped to keep the payload bounded.
+function rankUpcMatches(matches: UpcMatch[], cap = 10): UpcMatch[] {
+  const seen = new Set<string>();
+  const deduped: { m: UpcMatch; i: number }[] = [];
+  for (const m of matches) {
+    const key = matchDedupeKey(m);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push({ m, i: deduped.length });
+  }
+  const rank = (m: UpcMatch) => (m.source === "tiktok" ? 0 : 1);
+  return deduped
+    .sort((a, b) => rank(a.m) - rank(b.m) || a.i - b.i)
+    .map((x) => x.m)
+    .slice(0, cap);
+}
+
+// Resolve a product *image* (URL) to ranked product candidates in the shared
+// UpcMatch shape — the candidate shape /api/upc-lookup returns. SerpApi Google
+// Lens turns the image into visual matches; each is mapped to a "google_lens"
+// UpcMatch, and the top few are resolved against ScrapeCreators so any that hit
+// a TikTok Shop listing are upgraded to a "tiktok" match and boosted to the top.
+// Gated on SERPAPI_API_KEY. Cached by image URL to control cost; `debug`
+// bypasses the cache and echoes the raw Lens payload.
+export async function lookupProductByLens(
+  imageUrl: string,
+  opts: { debug?: boolean } = {},
+): Promise<LensLookup> {
+  const url = String(imageUrl || "").trim();
+  if (!url) throw new Error("image url is required");
+
+  const serpApiKey = envValue("SERPAPI_API_KEY");
+  if (!serpApiKey) {
+    return {
+      ok: false,
+      image: url,
+      error: "lens lookup unavailable: SERPAPI_API_KEY is not configured",
+    };
+  }
+
+  const cacheKey = await hashKey(url);
+  if (!opts.debug) {
+    const cached = await cacheGet<LensLookup>("lens", cacheKey);
+    if (cached) return cached;
+  }
+
+  const { lookup, matchErrored } = await computeLensLookup(
+    url,
+    serpApiKey,
+    opts.debug,
+  );
+
+  if (!opts.debug) {
+    // As in lookupProductByUpc/Image: a transient ScrapeCreators failure
+    // re-checks within the hour instead of pinning a stale ranking for the day.
+    const ttl = matchErrored || !lookup.ok ? lookupCacheNegTtl() : lookupCacheTtl();
+    await cacheSet("lens", cacheKey, lookup, ttl);
+  }
+  return lookup;
+}
+
+async function computeLensLookup(
+  url: string,
+  serpApiKey: string,
+  debug = false,
+): Promise<{ lookup: LensLookup; matchErrored: boolean }> {
+  const debugInfo: SerpDebug | undefined = debug ? {} : undefined;
+  const lensCandidates = await fetchGoogleLensProducts(url, serpApiKey, debugInfo);
+
+  if (!lensCandidates.length) {
+    return {
+      lookup: {
+        ok: false,
+        image: url,
+        error: "No product matches for that image",
+        candidates: [],
+        debug: debugInfo,
+      },
+      matchErrored: false,
+    };
+  }
+
+  // Resolve the top candidates against ScrapeCreators in parallel (bounded by
+  // lensTiktokResolveCap to cap cost). resolveTiktokMatchByName never throws, so
+  // a failed call just yields a null match (and flags errored for caching).
+  const toResolve = lensCandidates.slice(0, lensTiktokResolveCap());
+  const resolved = await Promise.all(
+    toResolve.map((c) => resolveTiktokMatchByName(c.title)),
+  );
+
+  let matchErrored = false;
+  const matches: UpcMatch[] = lensCandidates.map((c, i) => {
+    if (i < resolved.length) {
+      const { match, errored } = resolved[i];
+      if (errored) matchErrored = true;
+      if (match) return match; // "tiktok"-tagged, richer in-platform listing
+    }
+    return lensCandidateToMatch(c); // "google_lens" visual match
+  });
+
+  const candidates = rankUpcMatches(matches, 10);
+
+  return {
+    lookup: {
+      ok: true,
+      image: url,
+      source: "googlelens",
+      candidates,
+      match: candidates[0] ?? null,
+      debug: debugInfo,
+    },
+    matchErrored,
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ import {
   fetchSampleValuationWithEdits,
   listUnpricedSamples,
   lookupProductByImage,
+  lookupProductByLens,
   lookupProductByUpc,
   lookupProductDetails,
   updateSamplePrice,
@@ -780,6 +781,55 @@ export async function legacyHandler(req: Request): Promise<Response> {
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return corsJson({ ok: false, imageUrl, error: msg }, 502);
+        }
+      }
+
+      // Image lookup variant for the inventory app's "Find by photo" flow:
+      // resolve a public product IMAGE (URL) to ranked candidates in the same
+      // UpcMatch shape /api/upc-lookup returns. SerpApi Google Lens visual
+      // matches are mapped to UpcMatch and any that resolve to a TikTok Shop
+      // listing (via ScrapeCreators) are boosted and tagged source:"tiktok";
+      // match == candidates[0]. Gated on SERPAPI_API_KEY, cached by image URL.
+      // ?debug=1 echoes the raw Lens payload (mirrors upc-lookup), bypassing the
+      // cache. Cross-origin GET; carries CORS + an OPTIONS preflight.
+      if (pathname === "/api/lens-lookup") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "GET") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        const image =
+          (url.searchParams.get("image") || url.searchParams.get("url") || "").trim();
+        const debug = url.searchParams.get("debug") === "1";
+        // The image must be a public http(s) URL Lens can fetch — reject missing
+        // or non-http(s) values up front rather than handing SerpApi garbage.
+        let validImage = false;
+        if (image) {
+          try {
+            const proto = new URL(image).protocol;
+            validImage = proto === "http:" || proto === "https:";
+          } catch {
+            validImage = false;
+          }
+        }
+        if (!validImage) {
+          return corsJson(
+            {
+              ok: false,
+              error: "image must be an http(s) URL (?image=<url-encoded url>)",
+            },
+            400,
+          );
+        }
+        try {
+          const result = await lookupProductByLens(image, { debug });
+          // SERPAPI_API_KEY unset → the feature is unavailable, not a bad request.
+          const status = !result.ok && /SERPAPI_API_KEY/.test(result.error || "")
+            ? 503
+            : 200;
+          return corsJson(result, status);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson({ ok: false, image, error: msg }, 502);
         }
       }
 


### PR DESCRIPTION
## What

Adds `GET /api/lens-lookup?image=<url-encoded public image url>` — the image-search endpoint the inventory app's "Find by photo" flow needs. It hosts a photo at a public URL (`admin.thirsty.store/api/image/<id>`) and wants the **same candidate shape** `/api/upc-lookup` returns.

`/api/image-lookup` already runs SerpApi Google Lens, but only returns candidate *titles* and resolves the single best one to TikTok. This endpoint maps **every** Lens visual match into the shared `UpcMatch` shape and ranks them.

## Behavior

Response: `{ ok, image, match?: UpcMatch | null, candidates?: UpcMatch[], error? }`

- **Ranked best-first**, `match == candidates[0]`.
- Each Lens visual match → a `UpcMatch` tagged `source: "google_lens"` (image/price/seller pulled from the Lens payload). The top few (bounded by `LENS_TIKTOK_RESOLVE_CAP`, default 5) are resolved via ScrapeCreators; any that hit a TikTok Shop listing are **upgraded to `source: "tiktok"` and boosted above the rest**.
- `price` is always a number (`0` when unknown); candidates **de-duped** (by product id / source URL / name) and **capped at 10**.
- `?debug=1` echoes the raw Lens payload and bypasses the cache (mirrors `upc-lookup`). Cached by image URL with the same positive/negative TTL policy as the other lookups.
- `image` validated as an http(s) URL up front → missing/garbage returns **400**, no crash. `SERPAPI_API_KEY` unset → **503**.

## Reuse / consistency

Reuses the existing Lens + ScrapeCreators helpers rather than forking a parallel path:
- `fetchGoogleLensProducts` now carries `image`/`price`/`seller` per candidate (additive; `image-lookup` still only reads `title`).
- `resolveTiktokMatchByName` tags its match `source: "tiktok"`.
- New optional `source` field on `UpcMatch` records provenance (`"tiktok" | "google_lens"`) consistently across the upc/image/lens endpoints.

## Verify

```
curl "https://<host>/api/lens-lookup?image=https%3A%2F%2Fadmin.thirsty.store%2Fapi%2Fimage%2F<id>" | jq
# -> candidates[] of UpcMatch objects, match == candidates[0]
curl "https://<host>/api/lens-lookup?image=not-a-url" -i   # -> 400, no crash
```

## Tests

`core/lens_lookup_test.ts` (5 new tests) — gating on `SERPAPI_API_KEY`, ranking/boosting TikTok hits, de-dupe, the all-`google_lens` fallback, the no-matches case, and `?debug` cache-bypass. Full suite: **12 passed / 0 failed**. `deno check core/samples.ts` passes. (`deno check main.ts` has a pre-existing unrelated `Uint8Array`/`Response` error in the barcode handler, present on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)