### PR TITLE
Add GET /api/product-by-url — resolve a TikTok product-page URL to a product

### DIFF
--- a/core/product_by_url_test.ts
+++ b/core/product_by_url_test.ts
@@ -1,0 +1,283 @@
+import { expect } from "@std/expect";
+import { lookupProductByTiktokUrl, resolveTiktokProductUrl } from "./samples.ts";
+
+const PRODUCT_ID = "1731435940099691085";
+
+// A ScrapeCreators by-URL product response (the happy path: /v1/tiktok/product).
+const PRODUCT_BODY = {
+  product_info: {
+    product_base: {
+      title: "Acme Hydro Bottle 32oz",
+      price: { min_sku_original_price: 19.99 },
+      images: [{ url_list: ["https://img.example.com/bottle.jpg"] }],
+    },
+    seller: { name: "Acme Shop" },
+  },
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function withScKey(fn: () => Promise<void>): Promise<void> {
+  const prev = Deno.env.get("SCRAPECREATORS_API_KEY");
+  Deno.env.set("SCRAPECREATORS_API_KEY", "test-sc");
+  return fn().finally(() => {
+    if (prev === undefined) Deno.env.delete("SCRAPECREATORS_API_KEY");
+    else Deno.env.set("SCRAPECREATORS_API_KEY", prev);
+  });
+}
+
+// --- URL id extraction (no network for the full-url forms) -----------------
+
+Deno.test("resolves the id from a shop.tiktok.com /view/product url", async () => {
+  const result = await resolveTiktokProductUrl(
+    `https://shop.tiktok.com/view/product/${PRODUCT_ID}?source=liveManager&region=us`,
+  );
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+});
+
+Deno.test("resolves the id from a www.tiktok.com /shop/pdp/<slug>/<id> url", async () => {
+  const result = await resolveTiktokProductUrl(
+    `https://www.tiktok.com/shop/pdp/acme-hydro-bottle/${PRODUCT_ID}`,
+  );
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+});
+
+Deno.test("resolves the id from a trailing-id url", async () => {
+  const result = await resolveTiktokProductUrl(
+    `https://shop.tiktok.com/some/other/path/${PRODUCT_ID}`,
+  );
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+});
+
+Deno.test("a numeric query value is not mistaken for the id", async () => {
+  const result = await resolveTiktokProductUrl(
+    `https://shop.tiktok.com/view/product/${PRODUCT_ID}?source=998877665544`,
+  );
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+});
+
+Deno.test("rejects a non-TikTok url", async () => {
+  const result = await resolveTiktokProductUrl(
+    "https://www.amazon.com/dp/B0001234567",
+  );
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toMatch(/TikTok/i);
+});
+
+Deno.test("rejects a TikTok url with no extractable id", async () => {
+  const result = await resolveTiktokProductUrl("https://www.tiktok.com/@someone");
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toMatch(/product id/i);
+});
+
+Deno.test("rejects empty and malformed urls", async () => {
+  expect((await resolveTiktokProductUrl("")).ok).toBe(false);
+  expect((await resolveTiktokProductUrl("not a url")).ok).toBe(false);
+});
+
+Deno.test("follows a short link server-side then extracts the id", async () => {
+  const realFetch = globalThis.fetch;
+  // fetch() with redirect:"follow" surfaces the final url on Response.url. That
+  // getter can't be passed to the constructor, so shadow it on the instance to
+  // simulate the short link having redirected to the final PDP url.
+  globalThis.fetch = (() => {
+    const res = new Response("", { status: 200 });
+    Object.defineProperty(res, "url", {
+      value: `https://www.tiktok.com/shop/pdp/acme/${PRODUCT_ID}`,
+    });
+    return Promise.resolve(res);
+  }) as typeof fetch;
+  try {
+    const result = await resolveTiktokProductUrl("https://vt.tiktok.com/ZSabc123/");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+Deno.test("a short link that doesn't resolve to an id is a clean miss", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    const res = new Response("", { status: 200 });
+    Object.defineProperty(res, "url", { value: "https://www.tiktok.com/foryou" });
+    return Promise.resolve(res);
+  }) as typeof fetch;
+  try {
+    const result = await resolveTiktokProductUrl("https://vm.tiktok.com/ZSxyz/");
+    expect(result.ok).toBe(false);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// Regression: when the short-link redirect can't be followed (network error /
+// timeout), a numeric short-code path must NOT be mis-read as a product id.
+Deno.test("an unresolvable short link doesn't mis-read a numeric short code", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (() =>
+    Promise.reject(new Error("network"))) as typeof fetch;
+  try {
+    const result = await resolveTiktokProductUrl("https://vt.tiktok.com/1234567890/");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/short link/i);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// --- ScrapeCreators lookup + UrlMatch mapping ------------------------------
+
+type ScCounter = { product: number; search: number };
+
+// Install a fetch that routes the by-URL product call to `onProduct` and counts
+// any name-search call separately — the by-url endpoint must NEVER name-search
+// (a search on the bare numeric id binds an arbitrary unrelated listing).
+function installScFetch(
+  counter: ScCounter,
+  onProduct: () => Response,
+): () => void {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const u = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    if (u.includes("api.scrapecreators.com") && u.includes("/v1/tiktok/product")) {
+      counter.product++;
+      return Promise.resolve(onProduct());
+    }
+    if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+      counter.search++;
+      return Promise.resolve(jsonResponse({ products: [] }));
+    }
+    return Promise.resolve(new Response("unexpected", { status: 404 }));
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+Deno.test("lookupProductByTiktokUrl maps the by-URL ScrapeCreators response", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    const restore = installScFetch(counter, () => jsonResponse(PRODUCT_BODY));
+    try {
+      const match = await lookupProductByTiktokUrl(PRODUCT_ID);
+      expect(match.ok).toBe(true);
+      expect(match.productId).toBe(PRODUCT_ID);
+      expect(match.name).toBe("Acme Hydro Bottle 32oz");
+      expect(match.price).toBe(19.99);
+      expect(match.image).toBe("https://img.example.com/bottle.jpg");
+      expect(match.seller).toBe("Acme Shop");
+      expect(match.source).toBe("tiktok");
+      expect(match.product).toEqual(PRODUCT_BODY);
+      expect(match.debug).toBeUndefined();
+      // Resolved strictly by URL — no name search.
+      expect(counter.product).toBe(1);
+      expect(counter.search).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("?debug echoes the raw ScrapeCreators payload", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    const restore = installScFetch(counter, () => jsonResponse(PRODUCT_BODY));
+    try {
+      const match = await lookupProductByTiktokUrl(PRODUCT_ID, { debug: true });
+      expect(match.debug?.scrapecreators).toEqual(PRODUCT_BODY);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Regression: an out-of-stock / unmapped-price product still resolves. price 0
+// is a valid result, not a "no product" miss, and the raw body is still echoed.
+Deno.test("a real product with no parseable price resolves with price 0", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    const body = {
+      product_info: { product_base: { title: "Real Product No Price" } },
+    };
+    const restore = installScFetch(counter, () => jsonResponse(body));
+    try {
+      const match = await lookupProductByTiktokUrl(PRODUCT_ID);
+      expect(match.ok).toBe(true);
+      expect(match.name).toBe("Real Product No Price");
+      expect(match.price).toBe(0);
+      expect(match.product).toEqual(body);
+      expect(counter.search).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Regression: a by-URL miss must NOT fall back to a name search on the numeric
+// id (which would bind an arbitrary unrelated listing). A hard miss throws.
+Deno.test("a by-URL failure never falls back to a name search", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    const restore = installScFetch(
+      counter,
+      () => new Response("upstream boom", { status: 500 }),
+    );
+    try {
+      await expect(lookupProductByTiktokUrl(PRODUCT_ID)).rejects.toThrow();
+      expect(counter.search).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Regression: a real id beginning with "9" must still use the by-URL lookup —
+// the "9"-prefix synthetic-id heuristic must not capture a genuine snowflake id.
+Deno.test("an id starting with 9 is looked up by URL, not name-searched", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    const restore = installScFetch(counter, () => jsonResponse(PRODUCT_BODY));
+    try {
+      const match = await lookupProductByTiktokUrl("9123456789012345678");
+      expect(match.ok).toBe(true);
+      expect(match.productId).toBe("9123456789012345678");
+      expect(counter.product).toBe(1);
+      expect(counter.search).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Regression: `product` is always present (null, not omitted) on an unresolved
+// lookup, so the serialized shape stays stable for the inventory app.
+Deno.test("product is null (present) when nothing resolves", async () => {
+  await withScKey(async () => {
+    const counter: ScCounter = { product: 0, search: 0 };
+    // A by-URL body that isn't a product object: no title/price/image, no raw.
+    const restore = installScFetch(counter, () => jsonResponse(null));
+    try {
+      const match = await lookupProductByTiktokUrl(PRODUCT_ID);
+      expect(match.ok).toBe(false);
+      expect(match.price).toBe(0);
+      expect(match.product).toBeNull();
+      expect(match.error).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -405,28 +405,7 @@ export async function lookupProductDetails(
     // Graylog offline -> proceed with the synthesized product below.
   }
 
-  const product: ProductAnalysis = existing ?? {
-    productId: id,
-    name: (name || "").trim() || id,
-    priceRange: "",
-    min_sku_original_price: 0,
-    category: "",
-    categoryRank: null,
-    seller: "",
-    creators: 0,
-    liveStreams: 0,
-    videos: 0,
-    gmv: 0,
-    customers: 0,
-    quantity: 0,
-    skuOrders: 0,
-    refunds: 0,
-    unitsRefunded: 0,
-    sampleCount: 0,
-    estimatedRetailValue: 0,
-    lastSeen: null,
-    image: null,
-  };
+  const product: ProductAnalysis = existing ?? minimalProduct(id, name);
 
   const lookup = await fetchScrapeCreatorsPrice(product);
   if (lookup.price <= 0) {
@@ -476,6 +455,250 @@ export async function lookupProductDetails(
     image: enriched.image ?? null,
     seller: enriched.seller || null,
     sourceUrl: lookup.sourceUrl || null,
+  };
+}
+
+// The bare ProductAnalysis a by-id/by-url ScrapeCreators lookup needs when the
+// product isn't in the shared catalog: the real id drives the by-URL PDP lookup
+// and the name (defaulting to the id) seeds the name-search fallback. Everything
+// else is a zero placeholder. Distinct from syntheticProduct(), which deliberately
+// "9"-prefixes the id to FORCE the name-search path; here we keep the real id so
+// the by-URL lookup is attempted first.
+function minimalProduct(id: string, name?: string): ProductAnalysis {
+  return {
+    productId: id,
+    name: (name || "").trim() || id,
+    priceRange: "",
+    min_sku_original_price: 0,
+    category: "",
+    categoryRank: null,
+    seller: "",
+    creators: 0,
+    liveStreams: 0,
+    videos: 0,
+    gmv: 0,
+    customers: 0,
+    quantity: 0,
+    skuOrders: 0,
+    refunds: 0,
+    unitsRefunded: 0,
+    sampleCount: 0,
+    estimatedRetailValue: 0,
+    lastSeen: null,
+    image: null,
+  };
+}
+
+// --- TikTok product-page URL -> product (for the inventory app) -------------
+// admin.thirsty.store lets a user paste/share a TikTok product URL; this turns
+// that URL into a product it can save as a sample (qr_code = productId,
+// product_json = product). Shape mirrors the inventory app's UpcMatch contract
+// plus an explicit `source` tag. `price` is always a number (0 when unknown,
+// never null) so the app can store it without null-handling.
+export type UrlMatch = {
+  ok: boolean;
+  productId: string;
+  name: string | null;
+  price: number;
+  image: string | null;
+  seller: string | null;
+  sourceUrl: string | null;
+  source: "tiktok";
+  // Raw ScrapeCreators response — the app persists this as product_json. Always
+  // present (null when unresolved) so the serialized shape stays stable.
+  product: Record<string, unknown> | null;
+  error?: string;
+  // Raw ScrapeCreators payload echoed under ?debug=1 (mirrors the other lookups).
+  debug?: SerpDebug;
+};
+
+// Short-link hosts that 30x-redirect to the real PDP url. They carry no id of
+// their own, so we follow the redirect server-side and extract from the target.
+const TIKTOK_SHORTLINK_HOSTS = new Set([
+  "vt.tiktok.com",
+  "vm.tiktok.com",
+  "t.tiktok.com",
+]);
+
+// Accept tiktok.com and any subdomain (shop.tiktok.com, www.tiktok.com, the
+// short-link hosts, regional variants like shop.tiktok.com stay covered).
+function isTiktokHost(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === "tiktok.com" || h.endsWith(".tiktok.com");
+}
+
+// Pull the numeric product id out of an already-final TikTok PDP url. Handles
+//   /view/product/<ID>            (shop.tiktok.com live-manager links)
+//   /shop/pdp/<slug>/<ID>         (www.tiktok.com share links)
+//   .../<ID>                      (any other path ending in the numeric id)
+// The query string is ignored so a numeric ?source=/&region= value can't be
+// mistaken for the id.
+function tiktokProductIdFromUrl(u: URL): string | null {
+  const path = u.pathname;
+  const patterns = [
+    /\/view\/product\/(\d{6,})/i,
+    /\/shop\/pdp\/[^/]+\/(\d{6,})/i,
+    /\/product\/(\d{6,})/i,
+  ];
+  for (const re of patterns) {
+    const m = path.match(re);
+    if (m) return m[1];
+  }
+  // Fallback: the last all-numeric path segment (TikTok ids are long).
+  const segments = path.split("/").filter(Boolean);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (/^\d{6,}$/.test(segments[i])) return segments[i];
+  }
+  return null;
+}
+
+// Canonical PDP url for a product id, used as the response sourceUrl when the
+// ScrapeCreators lookup didn't supply one.
+function canonicalPdpUrl(productId: string): string {
+  return `https://shop.tiktok.com/view/product/${productId}`;
+}
+
+// Follow a short link to its final url server-side. Best-effort: any failure
+// (network error, timeout, non-redirecting host) returns null so the caller
+// surfaces a clean 400 rather than a 5xx. Bounded by an 8s timeout; the body is
+// dropped since we only need the final resolved url.
+async function followShortLink(shortUrl: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const res = await fetch(shortUrl, {
+      method: "GET",
+      redirect: "follow",
+      headers: {
+        "user-agent":
+          "Mozilla/5.0 (compatible; thirsty-bot/1.0; +https://thirsty.store)",
+      },
+      signal: controller.signal,
+    });
+    await res.body?.cancel();
+    return res.url || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Resolve a pasted/shared TikTok product URL to a numeric product id. Validates
+// the host, follows vt/vm/t.tiktok.com short links server-side, then extracts
+// the id. Returns a clear error (caller -> 400) when the url isn't a TikTok url
+// or carries no extractable id. Never throws.
+export async function resolveTiktokProductUrl(
+  rawUrl: string,
+): Promise<
+  | { ok: true; productId: string; canonicalUrl: string }
+  | { ok: false; error: string }
+> {
+  const trimmed = String(rawUrl || "").trim();
+  if (!trimmed) return { ok: false, error: "url is required" };
+
+  let u: URL;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    return { ok: false, error: "Invalid url" };
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    return { ok: false, error: "Invalid url" };
+  }
+  if (!isTiktokHost(u.hostname)) {
+    return { ok: false, error: "Not a TikTok url" };
+  }
+
+  // Short links carry no id; follow the redirect server-side and extract from
+  // the resolved PDP url. Only trust a redirect that lands on a NON-short TikTok
+  // host — otherwise (network error, timeout, or a still-short url) the short
+  // code itself could be mis-read as a numeric id, so fail cleanly instead.
+  if (TIKTOK_SHORTLINK_HOSTS.has(u.hostname.toLowerCase())) {
+    let resolved = false;
+    const finalUrl = await followShortLink(u.href);
+    if (finalUrl) {
+      try {
+        const fu = new URL(finalUrl);
+        if (
+          isTiktokHost(fu.hostname) &&
+          !TIKTOK_SHORTLINK_HOSTS.has(fu.hostname.toLowerCase())
+        ) {
+          u = fu;
+          resolved = true;
+        }
+      } catch {
+        // keep resolved=false -> clean miss below
+      }
+    }
+    if (!resolved) {
+      return {
+        ok: false,
+        error: "Could not resolve that TikTok short link to a product",
+      };
+    }
+  }
+
+  const productId = tiktokProductIdFromUrl(u);
+  if (!productId) {
+    return {
+      ok: false,
+      error: "Could not find a product id in that TikTok url",
+    };
+  }
+  return { ok: true, productId, canonicalUrl: canonicalPdpUrl(productId) };
+}
+
+// Look a TikTok product id up via ScrapeCreators by its PDP url — the same
+// /v1/tiktok/product call /api/product-lookup uses (fetchScrapeCreatorsPriceByUrl)
+// — and map it to the UrlMatch contract. We resolve STRICTLY by URL because we
+// have the exact id, and deliberately do NOT fall back to the name search the
+// price-recovery path uses: the only "name" available here is the bare numeric
+// id, and a TikTok Shop search on a number binds an arbitrary unrelated listing
+// to the user's product. Unlike lookupProductDetails this never throws on a
+// missing price — a real product that's out of stock (or whose price field we
+// can't map) still resolves with price 0 and its raw body echoed for the
+// inventory app to persist. Transient 5xx/429 are retried inside
+// fetchScrapeCreatorsPriceByUrl; a hard ScrapeCreators failure throws (-> 502).
+export async function lookupProductByTiktokUrl(
+  productId: string,
+  opts: { debug?: boolean } = {},
+): Promise<UrlMatch> {
+  const id = productId.trim();
+  if (!id) throw new Error("productId is required");
+
+  const apiKey = envValue("SCRAPECREATORS_API_KEY") || envValue("API_KEY");
+  if (!apiKey) throw new Error("SCRAPECREATORS_API_KEY is not configured");
+  const base =
+    (envValue("SCRAPECREATORS_API_BASE") || DEFAULT_SCRAPECREATORS_BASE)
+      .replace(/\/+$/, "");
+  const region = envValue("SCRAPECREATORS_REGION") || DEFAULT_REGION;
+
+  const lookup = await fetchScrapeCreatorsPriceByUrl(
+    base,
+    apiKey,
+    region,
+    minimalProduct(id, id),
+  );
+
+  // A resolved listing carries a title, a price, or an image. price 0 alone is a
+  // valid result (out of stock / unmapped price field), so it doesn't gate `ok`.
+  const hasData = Boolean(lookup.title || lookup.price > 0 || lookup.image);
+
+  return {
+    ok: hasData,
+    productId: id,
+    name: lookup.title || null,
+    price: lookup.price || 0,
+    image: lookup.image ?? null,
+    seller: lookup.seller ?? null,
+    sourceUrl: lookup.sourceUrl || canonicalPdpUrl(id),
+    source: "tiktok",
+    product: lookup.product ?? null,
+    ...(hasData
+      ? {}
+      : { error: "ScrapeCreators returned no product for that url" }),
+    ...(opts.debug ? { debug: { scrapecreators: lookup.product ?? null } } : {}),
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -13,8 +13,10 @@ import {
   fetchSampleValuationWithEdits,
   listUnpricedSamples,
   lookupProductByImage,
+  lookupProductByTiktokUrl,
   lookupProductByUpc,
   lookupProductDetails,
+  resolveTiktokProductUrl,
   updateSamplePrice,
   upsertSampleProduct,
 } from "./core/samples.ts";
@@ -780,6 +782,47 @@ export async function legacyHandler(req: Request): Promise<Response> {
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return corsJson({ ok: false, imageUrl, error: msg }, 502);
+        }
+      }
+
+      // Resolve a pasted/shared TikTok product-page URL to a product for the
+      // inventory app (admin.thirsty.store), which saves it as a sample. Extract
+      // the numeric product id from the url (following vt/vm/t.tiktok.com short
+      // links server-side), then run the same ScrapeCreators lookup
+      // /api/product-lookup uses. A bad/non-TikTok url or one with no id is a 400;
+      // a ScrapeCreators outage is a 502. ?debug=1 echoes the raw ScrapeCreators
+      // payload. Cross-origin GET, carries CORS.
+      if (pathname === "/api/product-by-url") {
+        if (req.method !== "GET") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        const rawUrl = (url.searchParams.get("url") || "").trim();
+        if (!rawUrl) {
+          return corsJson(
+            { ok: false, error: "url is required (?url=<tiktok product url>)" },
+            400,
+          );
+        }
+        const resolved = await resolveTiktokProductUrl(rawUrl);
+        if (!resolved.ok) {
+          return corsJson({ ok: false, error: resolved.error }, 400);
+        }
+        const debug = url.searchParams.get("debug") === "1";
+        try {
+          return corsJson(
+            await lookupProductByTiktokUrl(resolved.productId, { debug }),
+          );
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson(
+            {
+              ok: false,
+              productId: resolved.productId,
+              source: "tiktok",
+              error: msg,
+            },
+            502,
+          );
         }
       }
 


### PR DESCRIPTION
## What

Adds `GET /api/product-by-url?url=<url-encoded product page url>` so the inventory app (admin.thirsty.store) can turn a pasted/shared TikTok product-page URL into a product it saves as a sample.

It reuses the existing ScrapeCreators lookup + field mapping, staying consistent with `/api/product-lookup` and `/api/upc-lookup`.

## How it works

1. **Extract the product id** (`resolveTiktokProductUrl`): validates the host is `*.tiktok.com`, then extracts the numeric id from:
   - `https://shop.tiktok.com/view/product/<ID>?source=...`
   - `https://www.tiktok.com/shop/pdp/<slug>/<ID>`
   - `https://shop.tiktok.com/.../<ID>` (trailing-id)
   - **short links** (`vt`/`vm`/`t.tiktok.com`) — followed **server-side** to the final URL, then extracted. The query string is ignored so a numeric `?source=`/`&region=` value can't be mistaken for the id.
2. **Look it up** (`lookupProductByTiktokUrl`): resolves strictly by its PDP url via the same `/v1/tiktok/product` call `/api/product-lookup` uses.
3. **Return** the inventory app's `UpcMatch`-shaped contract:
   ```json
   { "ok": true, "productId": "1731435940099691085", "name": "...", "price": 0,
     "image": "...", "seller": "...", "sourceUrl": "...", "source": "tiktok",
     "product": { /* raw ScrapeCreators response */ } }
   ```
   `price` is always a number (`0` when unknown, never `null`); `product` is always present (`null` when unresolved). `?debug=1` echoes the raw ScrapeCreators payload.

- **400** when the url is missing, not a TikTok url, or carries no extractable id.
- **502** on a ScrapeCreators outage. **405** for non-GET. Cross-origin GET (CORS), like the sibling endpoints.
- Persistence is **not** this endpoint's job — the inventory app owns the samples Postgres.

## Notable design choice

Resolves **by URL only** — no numeric-id name-search fallback. The price-recovery path (`fetchScrapeCreatorsPrice`) falls back to a TikTok Shop *name search* when the by-URL price is 0, but the only "name" available here is the bare numeric id, and a search on a number binds an **arbitrary unrelated listing** to the user's product. An out-of-stock / unmapped-price product still resolves (`price: 0`, `ok: true`) with its raw body echoed.

## Verify

```
curl "https://<host>/api/product-by-url?url=https%3A%2F%2Fshop.tiktok.com%2Fview%2Fproduct%2F1731435940099691085%3Fsource%3DliveManager%26region%3Dus" | jq
# -> { ok:true, productId:"1731435940099691085", product:{...}, ... }
```

## Testing

- `core/product_by_url_test.ts` — 16 tests (URL extraction across all forms, short-link follow + unresolvable-short-link safety, by-URL mapping, `?debug`, price-0 resolves `ok:true`, no name-search fallback, `9`-prefixed ids hit by-URL, `product` always present).
- Full `deno test core/` suite: 23/23 pass.
- In-process route smoke test through the real `legacyHandler`: 20/20 (happy path = the verify example, CORS, debug, all 400s, 405, 502-on-outage).
- `deno check main.ts` clean except the pre-existing barcode `Uint8Array` type error (unrelated).

The implementation went through an adversarial multi-agent review; the findings (notably the name-search-fallback data-integrity bug) are addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)