### PR TITLE
Include Product Analysis samples in audit-mode catalog search

### DIFF
--- a/core/samples.ts
+++ b/core/samples.ts
@@ -93,21 +93,67 @@ const DEFAULT_STORE_PATH = ".thirsty/sample-prices.json";
 const DEFAULT_SCRAPECREATORS_BASE = "https://api.scrapecreators.com";
 const DEFAULT_REGION = "US";
 
+// Every tracked sample that still needs a price or already carries one -- the
+// backlog the Product Analysis dashboard counts as "unpriced + priced". Kept in
+// one place so /api/unpriced-samples and the catalog merge (listSampleProducts)
+// can never disagree on which samples make up the set.
+async function sampleProductsFromStore(
+  store: SampleStore,
+): Promise<UnpricedSample[]> {
+  const products = await fetchProductsWithStored(1000, store);
+  return products
+    .filter((product) => product.sampleCount > 0)
+    .filter((product) =>
+      product.min_sku_original_price <= 0 || store.edits[product.productId]
+    )
+    .map((product) => sampleFromProduct(product, store.edits[product.productId]));
+}
+
+// The full Product Analysis backlog (unbounded, unsorted-for-paging). The
+// catalog endpoint folds these into /api/products so audit-mode search in the
+// tracker can match samples that live only in Graylog, not yet in the Postgres
+// snapshot.
+//
+// /api/products is polled cross-origin by the tracker and each call would
+// otherwise pay two serial Graylog round-trips (edit records + recent products),
+// so the result is memoized briefly. The backlog changes slowly and a few
+// seconds of staleness is fine for catalog search; the Product Analysis
+// dashboard (listUnpricedSamples) bypasses this memo and stays fully live. The
+// in-flight promise is shared so concurrent polls collapse to one fetch, and a
+// rejection is never cached -- a Graylog outage retries on the next call rather
+// than being pinned for the whole TTL.
+const SAMPLE_PRODUCTS_TTL_MS = 60_000;
+let sampleProductsCache:
+  | { at: number; value: Promise<UnpricedSample[]> }
+  | null = null;
+
+export function listSampleProducts(): Promise<UnpricedSample[]> {
+  const now = Date.now();
+  if (
+    sampleProductsCache &&
+    now - sampleProductsCache.at < SAMPLE_PRODUCTS_TTL_MS
+  ) {
+    return sampleProductsCache.value;
+  }
+
+  const value = (async () => sampleProductsFromStore(await loadStore()))();
+  const entry = { at: now, value };
+  sampleProductsCache = entry;
+  // Don't pin a Graylog outage for the full TTL: drop the entry if it rejects so
+  // the next call retries instead of replaying the failure.
+  value.catch(() => {
+    if (sampleProductsCache === entry) sampleProductsCache = null;
+  });
+  return value;
+}
+
 export async function listUnpricedSamples(
   query = "",
   limit = 100,
 ): Promise<UnpricedSampleList> {
   const store = await loadStore();
-  const products = await fetchProductsWithStored(1000, store);
   const normalizedQuery = query.trim().toLowerCase();
-  const items = products
-    .filter((product) => product.sampleCount > 0)
-    .filter((product) =>
-      product.min_sku_original_price <= 0 || store.edits[product.productId]
-    )
-    .map((product) =>
-      sampleFromProduct(product, store.edits[product.productId])
-    )
+  const items = (await sampleProductsFromStore(store))
     .filter((sample) => matchesQuery(sample, normalizedQuery))
     .sort((a, b) =>
       Number(a.priced) - Number(b.priced) || a.name.localeCompare(b.name)

--- a/main.ts
+++ b/main.ts
@@ -11,10 +11,12 @@ import {
   fetchPriceForSample,
   fetchProductWithEdits,
   fetchSampleValuationWithEdits,
+  listSampleProducts,
   listUnpricedSamples,
   lookupProductByImage,
   lookupProductByUpc,
   lookupProductDetails,
+  type UnpricedSample,
   updateSamplePrice,
   upsertSampleProduct,
 } from "./core/samples.ts";
@@ -173,6 +175,25 @@ function sampleRowToKioskProduct(row: Record<string, unknown>): KioskProduct {
     estimatedRetailValue: 0,
     lastSeen: row.created_at ? new Date(String(row.created_at)).toISOString() : null,
     image: row.picture_url ? String(row.picture_url) : null,
+  };
+}
+
+// Map a Product Analysis sample (Graylog-backed) into the same kiosk catalog
+// shape as sampleRowToKioskProduct, so /api/products can surface it alongside
+// the Postgres catalog for audit-mode search. `sample.name` already reflects any
+// apiTitle edit (see sampleFromProduct).
+function sampleProductToKioskProduct(sample: UnpricedSample): KioskProduct {
+  return {
+    productId: sample.productId,
+    name: sample.name,
+    priceRange: sample.price > 0 ? `$${sample.price.toFixed(2)}` : "",
+    min_sku_original_price: sample.price,
+    category: "",
+    seller: sample.apiSeller || "Unknown seller",
+    sampleCount: sample.sampleCount,
+    estimatedRetailValue: sample.sampleValue,
+    lastSeen: sample.lastSeen,
+    image: sample.image,
   };
 }
 
@@ -693,10 +714,31 @@ export async function legacyHandler(req: Request): Promise<Response> {
           ? parseInt(url.searchParams.get("limit")!, 10)
           : undefined;
         const rows = await Samples.list("-created_at") as Record<string, unknown>[];
-        const catalog = rows
+        const base = rows
           .map(sampleRowToKioskProduct)
           .filter((p) => p.productId && p.name);
-        return corsJson(limit ? catalog.slice(0, limit) : catalog);
+
+        // Fold the live Product Analysis backlog (Graylog-backed) into the
+        // catalog so audit-mode search in the tracker can match samples that
+        // exist only in Graylog -- not yet in this Postgres snapshot. Deduped by
+        // productId with the Postgres catalog winning on overlap (both key on
+        // the TikTok product id -- see seed-from-kiosk.ts). When the merge
+        // succeeds we return the full union so every sample stays searchable;
+        // `limit` only bounds the Postgres-only catalog we fall back to when
+        // Graylog is unavailable (the merge must never take the catalog down).
+        try {
+          const byId = new Map(base.map((p) => [p.productId, p]));
+          for (const sample of await listSampleProducts()) {
+            if (!sample.productId || !sample.name || byId.has(sample.productId)) {
+              continue;
+            }
+            byId.set(sample.productId, sampleProductToKioskProduct(sample));
+          }
+          return corsJson([...byId.values()]);
+        } catch (error) {
+          console.error("Product Analysis merge into /api/products failed:", error);
+          return corsJson(limit ? base.slice(0, limit) : base);
+        }
       }
 
       // Live ScrapeCreators detail lookup by product id. Consumed cross-origin


### PR DESCRIPTION
## Problem

The Inventory app's **Audit** mode (`admin.thirsty.store`, external) shows catalog candidates by fetching `https://thirsty.store/api/products?limit=500` — served by this repo. That endpoint was built **only** from the Postgres `samples` snapshot, while the 571-item **Product Analysis** list (`/api/unpriced-samples`) is the *live Graylog* set. The snapshot is stale, so samples tracked since the last `deno task seed:kiosk` never appeared as catalog candidates.

## Fix

`/api/products` now folds the live Product Analysis backlog into the catalog:
- **Deduped by `productId`, Postgres wins on overlap** — safe because `seed-from-kiosk.ts` makes Postgres `qr_code` == the TikTok `productId` == Graylog `ProductAnalysis.productId`.
- **Full union returned** so every sample stays searchable. A Graylog outage **degrades to the Postgres-only catalog** (`limit`-bounded) — the merge can never take the catalog down.
- `listSampleProducts()` is **memoized ~60s** so the polled endpoint doesn't pay two serial Graylog round-trips per request; the Product Analysis dashboard bypasses the memo and stays live.

Blast radius is contained: `/api/products` is consumed only by the tracker/audit app (the kiosk storefront SPA uses `/api/samples`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)