### PR TITLE
Add GET /api/product-search?q= (TikTok Shop keyword search)

### DIFF
--- a/core/product_search_test.ts
+++ b/core/product_search_test.ts
@@ -1,0 +1,197 @@
+import { expect } from "@std/expect";
+import { lookupProductsByKeyword } from "./samples.ts";
+
+// ScrapeCreators shop/search hit: one priced and one unpriced listing for the
+// same query, so we can assert the priced listing ranks first.
+const SEARCH_BODY = {
+  products: [
+    {
+      title: "Acme Widget Mini",
+      price: 0,
+      url: "https://www.tiktok.com/shop/pdp/acme-widget-mini/1111111111",
+      shop_name: "Mini Shop",
+      cover: "https://img.example.com/mini.jpg",
+    },
+    {
+      title: "Acme Widget Pro",
+      price: 24.99,
+      url: "https://www.tiktok.com/shop/pdp/acme-widget-pro/1234567890",
+      shop_name: "Acme Shop",
+      cover: "https://img.example.com/widget.jpg",
+    },
+  ],
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Mock fetch for the ScrapeCreators TikTok Shop search; `makeBody` is called per
+// request so a test can count calls or vary the response.
+function installSearchFetch(makeBody: () => unknown) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const u = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+      return Promise.resolve(jsonResponse(makeBody()));
+    }
+    return Promise.resolve(new Response("unexpected", { status: 404 }));
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+// Run with a ScrapeCreators key set (and API_KEY cleared so the fallback can't
+// mask an unset SCRAPECREATORS_API_KEY), restoring the prior environment after.
+function withScKey(fn: () => Promise<void>): Promise<void> {
+  const prevSc = Deno.env.get("SCRAPECREATORS_API_KEY");
+  const prevApi = Deno.env.get("API_KEY");
+  Deno.env.set("SCRAPECREATORS_API_KEY", "test-sc");
+  Deno.env.delete("API_KEY");
+  return fn().finally(() => {
+    if (prevSc === undefined) Deno.env.delete("SCRAPECREATORS_API_KEY");
+    else Deno.env.set("SCRAPECREATORS_API_KEY", prevSc);
+    if (prevApi === undefined) Deno.env.delete("API_KEY");
+    else Deno.env.set("API_KEY", prevApi);
+  });
+}
+
+Deno.test("product search requires a non-empty query", async () => {
+  await expect(lookupProductsByKeyword("   ")).rejects.toThrow(/query is required/);
+});
+
+Deno.test("product search is gated on SCRAPECREATORS_API_KEY", async () => {
+  const prevSc = Deno.env.get("SCRAPECREATORS_API_KEY");
+  const prevApi = Deno.env.get("API_KEY");
+  Deno.env.delete("SCRAPECREATORS_API_KEY");
+  Deno.env.delete("API_KEY");
+  try {
+    const result = await lookupProductsByKeyword("acme widget");
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/SCRAPECREATORS_API_KEY/);
+  } finally {
+    if (prevSc !== undefined) Deno.env.set("SCRAPECREATORS_API_KEY", prevSc);
+    if (prevApi !== undefined) Deno.env.set("API_KEY", prevApi);
+  }
+});
+
+Deno.test("product search returns ranked TikTok candidates and caches", async () => {
+  await withScKey(async () => {
+    let calls = 0;
+    const restore = installSearchFetch(() => {
+      calls++;
+      return SEARCH_BODY;
+    });
+    try {
+      // Unique query so a persisted KV cache from a prior run can't pre-answer.
+      const q = `acme ${crypto.randomUUID()}`;
+      const result = await lookupProductsByKeyword(q);
+
+      expect(result.ok).toBe(true);
+      expect(result.query).toBe(q);
+      expect(result.source).toBe("tiktok");
+      expect(result.candidates?.length).toBe(2);
+      // The priced listing ranks ahead of the unpriced one, and is the match.
+      expect(result.match?.productId).toBe("1234567890");
+      expect(result.candidates?.[0].name).toBe("Acme Widget Pro");
+      expect(result.candidates?.[0].price).toBe(24.99);
+      expect(result.candidates?.[0].seller).toBe("Acme Shop");
+      expect(result.candidates?.[1].productId).toBe("1111111111");
+      // The raw upstream `product` blob is stripped from search candidates (kept
+      // small so the cached value stays under Deno KV's 64 KiB limit).
+      expect(result.candidates?.[0].product).toBeUndefined();
+      expect(result.debug).toBeUndefined();
+      expect(calls).toBe(1);
+
+      // A second non-debug call for the same query is served from cache.
+      const again = await lookupProductsByKeyword(q);
+      expect(again.match?.productId).toBe("1234567890");
+      expect(calls).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("product search returns ok with no candidates on an empty result", async () => {
+  await withScKey(async () => {
+    const restore = installSearchFetch(() => ({ products: [] }));
+    try {
+      const q = `nomatch ${crypto.randomUUID()}`;
+      const result = await lookupProductsByKeyword(q);
+      expect(result.ok).toBe(true);
+      expect(result.candidates).toEqual([]);
+      expect(result.match).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("product search clamps the limit", async () => {
+  await withScKey(async () => {
+    const restore = installSearchFetch(() => SEARCH_BODY);
+    try {
+      const q = `acme ${crypto.randomUUID()}`;
+      const result = await lookupProductsByKeyword(q, { limit: 1 });
+      expect(result.candidates?.length).toBe(1);
+      expect(result.candidates?.[0].productId).toBe("1234567890");
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("product search debug echoes the raw payload and bypasses cache", async () => {
+  await withScKey(async () => {
+    let calls = 0;
+    const restore = installSearchFetch(() => {
+      calls++;
+      return SEARCH_BODY;
+    });
+    try {
+      const q = `acme ${crypto.randomUUID()}`;
+      const first = await lookupProductsByKeyword(q, { debug: true });
+      expect(first.debug?.scrapecreators).toEqual(SEARCH_BODY);
+
+      // A second debug call re-runs the search (cache bypassed).
+      await lookupProductsByKeyword(q, { debug: true });
+      expect(calls).toBe(2);
+    } finally {
+      restore();
+    }
+  });
+});
+
+Deno.test("product search throws on a ScrapeCreators failure (-> 502)", async () => {
+  await withScKey(async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: string | URL | Request) => {
+      const u = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+      if (u.includes("api.scrapecreators.com") && u.includes("/shop/search")) {
+        return Promise.resolve(new Response("upstream", { status: 500 }));
+      }
+      return Promise.resolve(new Response("unexpected", { status: 404 }));
+    }) as typeof fetch;
+    try {
+      // Unique query so the failure can't be served from a cached result.
+      await expect(
+        lookupProductsByKeyword(`fail ${crypto.randomUUID()}`),
+      ).rejects.toThrow();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -888,6 +888,23 @@ export type LensLookup = {
   debug?: SerpDebug;
 };
 
+// Result of the /api/product-search endpoint: a live TikTok Shop keyword search
+// via ScrapeCreators, every result mapped to the shared UpcMatch shape and
+// ranked best-first (priced listings first, then by title-match score) — the
+// candidate shape /api/upc-lookup returns. Backs the inventory app's catalog
+// search box. Keyed by `query` (echoed back).
+export type SearchLookup = {
+  ok: boolean;
+  query: string;
+  // Ranked candidates, best-first; match is candidates[0] (null when none).
+  match?: UpcMatch | null;
+  candidates?: UpcMatch[];
+  error?: string;
+  source?: "tiktok";
+  // Raw ScrapeCreators payload when the caller asks for debug (?debug=1).
+  debug?: SerpDebug;
+};
+
 // UPCitemdb: trial endpoint needs no key (rate-limited ~100/day, shared). A paid
 // plan key (UPCITEMDB_API_KEY) switches to the authenticated endpoint headers.
 async function fetchUpcItemDb(upc: string): Promise<UpcItem | null> {
@@ -1739,6 +1756,94 @@ async function computeLensLookup(
       debug: debugInfo,
     },
     matchErrored,
+  };
+}
+
+// A keyword search wants a fuller result set than the single-match lookups
+// (which cap at 10); allow up to SEARCH_MAX_LIMIT, defaulting to SEARCH_DEFAULT.
+const SEARCH_DEFAULT_LIMIT = 20;
+const SEARCH_MAX_LIMIT = 50;
+
+function clampSearchLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return SEARCH_DEFAULT_LIMIT;
+  return Math.min(SEARCH_MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+// Resolve a free-text query to ranked TikTok Shop listings via ScrapeCreators,
+// in the shared UpcMatch shape /api/upc-lookup returns; match == candidates[0].
+// Gated on SCRAPECREATORS_API_KEY (|| API_KEY) — returns ok:false with that
+// message when unset so the caller can answer 503. Cached by (limit, query): a
+// populated result lives for the positive TTL, an empty "no results" only for
+// the negative TTL so new inventory surfaces within the hour. A hard
+// ScrapeCreators failure throws (caller -> 502) and is not cached. `debug`
+// bypasses the cache and echoes the raw ScrapeCreators payload.
+export async function lookupProductsByKeyword(
+  query: string,
+  opts: { limit?: number; debug?: boolean } = {},
+): Promise<SearchLookup> {
+  const trimmed = String(query || "").replace(/\s+/g, " ").trim();
+  if (!trimmed) throw new Error("query is required");
+
+  const apiKey = envValue("SCRAPECREATORS_API_KEY") || envValue("API_KEY");
+  if (!apiKey) {
+    return {
+      ok: false,
+      query: trimmed,
+      error:
+        "product search unavailable: SCRAPECREATORS_API_KEY is not configured",
+    };
+  }
+
+  const limit = clampSearchLimit(opts.limit);
+  // Case-sensitive cache identity so the echoed `query` always matches the
+  // caller's request (the ranking itself is case-insensitive regardless).
+  const cacheKey = await hashKey(`${limit}:${trimmed}`);
+  if (!opts.debug) {
+    const cached = await cacheGet<SearchLookup>("search", cacheKey);
+    if (cached) return cached;
+  }
+
+  const lookup = await computeProductSearch(trimmed, apiKey, limit, opts.debug);
+
+  if (!opts.debug) {
+    const ttl = lookup.candidates && lookup.candidates.length > 0
+      ? lookupCacheTtl()
+      : lookupCacheNegTtl();
+    await cacheSet("search", cacheKey, lookup, ttl);
+  }
+  return lookup;
+}
+
+async function computeProductSearch(
+  query: string,
+  apiKey: string,
+  limit: number,
+  debug = false,
+): Promise<SearchLookup> {
+  const base = (envValue("SCRAPECREATORS_API_BASE") || DEFAULT_SCRAPECREATORS_BASE)
+    .replace(/\/+$/, "");
+  const region = envValue("SCRAPECREATORS_REGION") || DEFAULT_REGION;
+
+  // A non-OK ScrapeCreators response throws here -> propagates to the endpoint as
+  // a 502 (mirrors /api/product-by-url); an empty-but-OK result is a clean miss.
+  const { body } = await fetchScrapeCreatorsSearchBody(base, apiKey, region, query);
+
+  // A keyword search returns a selection list (up to SEARCH_MAX_LIMIT), not a
+  // single enriched match, so drop each candidate's raw `product` blob: at this
+  // count it bloats the response and pushes the cached value past Deno KV's
+  // 64 KiB per-value limit (which silently disables cross-instance caching). The
+  // tracker resolves full detail for the chosen candidate via /api/product-lookup;
+  // the raw payload is still available here under ?debug=1.
+  const candidates = rankUpcMatches(tiktokSearchCandidates(body, query), limit)
+    .map(({ product: _product, ...rest }) => rest);
+
+  return {
+    ok: true,
+    query,
+    source: "tiktok",
+    candidates,
+    match: candidates[0] ?? null,
+    ...(debug ? { debug: { scrapecreators: body } } : {}),
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import {
   lookupProductByTiktokUrl,
   lookupProductByUpc,
   lookupProductDetails,
+  lookupProductsByKeyword,
   resolveTiktokProductUrl,
   type UnpricedSample,
   updateSamplePrice,
@@ -1163,6 +1164,47 @@ export async function legacyHandler(req: Request): Promise<Response> {
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return corsJson({ ok: false, image, error: msg }, 502);
+        }
+      }
+
+      // Keyword search for the inventory app's catalog search box: resolve a
+      // free-text query to ranked TikTok Shop listings (via ScrapeCreators) in
+      // the same UpcMatch shape /api/upc-lookup returns; match == candidates[0].
+      // Gated on SCRAPECREATORS_API_KEY, cached by (query, limit). Optional
+      // ?limit= (1..50, default 20). ?debug=1 echoes the raw ScrapeCreators
+      // payload, bypassing the cache. Cross-origin GET; carries CORS + an OPTIONS
+      // preflight.
+      if (pathname === "/api/product-search") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "GET") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        // Collapse internal whitespace + trim, matching lookupProductsByKeyword's
+        // own normalization so the echoed `query` is identical across 200/503/502.
+        const query = (url.searchParams.get("q") || url.searchParams.get("query") || "")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (!query) {
+          return corsJson(
+            { ok: false, error: "q is required (?q=<search terms>)" },
+            400,
+          );
+        }
+        const debug = url.searchParams.get("debug") === "1";
+        const limitParam = url.searchParams.get("limit");
+        const limit = limitParam ? Number(limitParam) : undefined;
+        try {
+          const result = await lookupProductsByKeyword(query, { limit, debug });
+          // SCRAPECREATORS_API_KEY unset → the feature is unavailable, not a bad
+          // request (mirrors /api/lens-lookup's SERPAPI_API_KEY handling).
+          const status =
+            !result.ok && /SCRAPECREATORS_API_KEY/.test(result.error || "")
+              ? 503
+              : 200;
+          return corsJson(result, status);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson({ ok: false, query, error: msg }, 502);
         }
       }
 


### PR DESCRIPTION
## Summary

Wraps ScrapeCreators' TikTok Shop keyword search (`/v1/tiktok/shop/search`) as a catalog search endpoint for the inventory/audit app, reusing the existing search + rank helpers so it returns the same `UpcMatch` candidate shape the tracker already consumes from `/api/upc-lookup` and `/api/lens-lookup`.

```
GET /api/product-search?q=jocko%20protein
→ { ok:true, query:"jocko protein", source:"tiktok",
    match:{...}, candidates:[ {productId,name,price,image,seller,sourceUrl,source:"tiktok"}, ... ] }
```

## Changes
- **`core/samples.ts`**: `SearchLookup` type + exported `lookupProductsByKeyword(query, { limit?, debug? })`.
  - Gated on `SCRAPECREATORS_API_KEY` (|| `API_KEY`) → `ok:false` when unset.
  - Ranked candidates (priced-first, then title-match), `match == candidates[0]`.
  - Cached by `(limit, query)`: populated results at the positive TTL, empty "no results" at the negative TTL so new inventory surfaces within the hour. `?debug=1` bypasses the cache and echoes the raw payload. A hard ScrapeCreators failure throws (→ 502).
  - Search candidates **drop the raw `product` blob** so the cached value stays under Deno KV's 64 KiB per-value limit; full detail for a chosen candidate is one `/api/product-lookup` call away.
- **`main.ts`**: handler with `OPTIONS` preflight + CORS, `?q=` (or `?query=`), optional `?limit=` (1–50, default 20). Status codes: 400 missing `q`, 405 non-GET, 503 key unset, 502 upstream failure, else 200.
- **`core/product_search_test.ts`**: 8 assertions across gating, ranking, caching, empty result, limit-clamp, debug passthrough, throw-on-failure, and `product`-blob stripping.

## Verification
- `deno check main.ts`: clean.
- `deno test -A core/`: **39 passed / 0 failed** (incl. 7 new keyword-search tests), against current `main`.
- **Adversarial multi-agent review** (correctness / caching-edgecases / consistency-fit → per-finding verification). Confirmed findings fixed: the KV-payload bloat (raw `product` stripped) and two query-echo nits; 5 findings correctly dismissed.

⚠️ Not exercised against live ScrapeCreators (no local credentials); logic is type-checked and unit-test-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)