### PR TITLE
Add sample-lifecycle skill + thirsty-samples MCP for status/sold writes

### DIFF
--- a/.claude/skills/sample-lifecycle/SKILL.md
+++ b/.claude/skills/sample-lifecycle/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sample-lifecycle
+description: >-
+  Update a sample's status, or mark a sample SOLD and attribute the resale
+  revenue to a creator account, in the LP Sample Tracker (thirsty.store /
+  admin.thirsty.store). Trigger whenever the user wants to change a sample's
+  state or log a resale — e.g. "mark <product> as sold", "this sold on eBay for
+  $40", "set <product> to cleared to sell", "reserve sample 42", "discontinue
+  this one", "log a resale", "attribute this sale to @wizardofdealz". Each action
+  writes the inventory truth to Postgres AND a Graylog event, so a creator's
+  resale revenue is immediately queryable. For READ-ONLY questions about the data
+  ("how much resale revenue did @x make", "which samples sold this month", "what's
+  in Graylog") use the graylog-query skill instead — this skill only WRITES.
+allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__mark_sample_sold
+---
+
+# sample-lifecycle
+
+Mutates a sample's lifecycle state through the **thirsty-samples** MCP server,
+which calls data-pimp's sample endpoints. Every action writes to **two** places:
+
+- **Postgres** (`public.samples` + `inventory_transactions`) — the inventory
+  source of truth, shared with the tracker UI.
+- **Graylog** — the durable analytics spine. Status changes and sales become
+  GELF events keyed by `product_id` (the sample's `qr_code`, the join key across
+  the whole lifecycle) so they can be read back by the `graylog-query` skill.
+
+This skill is **write-only**. Reading the data back (revenue reports, "who sold
+what") is the `graylog-query` skill's job — see *Reading it back* below.
+
+## Workflow 1 — Update a sample's status
+
+1. **Resolve the sample.** If the user named a product, call `list_samples` with
+   a `query` to find the row and its `id`. Prefer acting by `id`. If several
+   samples share a name/productId, show the matches and ask which one.
+2. **Validate the target status.** Call `list_sample_statuses` and confirm the
+   requested status is one of the exclusive lifecycle statuses — `available`,
+   `checked_out`, `reserved`, `cleared_to_sell`, `discontinued`. (`sold` is also
+   `kind:"status"` but is rejected here — route sales through Workflow 2.) Map
+   the user's words to the canonical `value` (e.g. "clear it to sell" →
+   `cleared_to_sell`).
+3. **Write it.** Call `update_sample_status` with `sampleId` (or `productId`),
+   `status`, and an optional `note`.
+4. **Report honestly.** Echo the result's `message`. The result shows what
+   persisted (`postgres.updated`, `graylog`). If `graylog` is `false`, say the
+   Graylog event did **not** write — don't report unqualified success.
+
+> "Sold" is **not** a plain status here. `update_sample_status` rejects it on
+> purpose, because a sale must attribute revenue to a creator → use Workflow 2.
+
+## Workflow 2 — Mark a sample SOLD (with creator attribution)
+
+This is the revenue path. The creator-attribution prompt is mandatory.
+
+1. **Resolve the sample** (as above, via `list_samples`). For a sale, prefer a
+   specific `sampleId` so you mark the right physical unit; if only a productId
+   is given and multiple unsold units match, ask which one.
+2. **Ask which creator gets the revenue.** This is the load-bearing step the
+   user asked for. Call `list_creators` and ask:
+   *"Which creator account should this resale revenue be attributed to?"*
+   Offer the @-handles it returns (real handles sort first). If the intended
+   handle isn't listed, confirm the exact spelling before proceeding — a typo
+   silently fragments that creator's revenue. Do not guess.
+3. **Gather the sale details.** Required: `salePrice` (gross) and `marketplace`
+   (`ebay`, `offerup`, `fbmarketplace`, …). Optional, for net profit:
+   `fees`, `shipping`, `costBasis` (net = sale − fees − shipping − cost), plus
+   `buyer`, `orderRef`, `note`. Ask for what's missing rather than assuming.
+4. **Write it.** Call `mark_sample_sold`. It sets the sample to `sold` with the
+   sale columns + a `sold` inventory transaction in Postgres, and emits the
+   Graylog revenue event (`creator` + `gmv_num` gross + `net_num`).
+5. **Report honestly.** Echo `message`, the computed `net`, and the attributed
+   `creator`. If `graylog` is `false`, the revenue event did **not** record —
+   flag it clearly (the sale won't show up for the creator until it's re-sent).
+   The `message` also warns if the Postgres audit transaction wasn't written.
+
+> **Re-selling is refused by default.** Marking an already-sold sample sold again
+> would double-count the creator's revenue (Graylog events are append-only). If
+> the user genuinely needs to re-attribute, confirm first, then pass
+> `force: true` to `mark_sample_sold`.
+
+## Reading it back — composing with `graylog-query`
+
+These events are written using `graylog-query`'s own conventions, so that
+read-only skill surfaces resale revenue **with no changes**. After a sale,
+revenue questions go to `graylog-query` (it lives in the `tok-scrape-main`
+project; run its script directly if it isn't loaded). Key recipes:
+
+**A creator's resale revenue (ever):**
+```bash
+python3 .../graylog-query/scripts/graylog_query.py --all \
+  -q '(creator:"@wizardofdealz" OR creator.keyword:"@wizardofdealz") AND sample_sold_json:*' \
+  --fields product_id,marketplace,gmv_num,net_num,sample_sold_json --sort timestamp:desc
+```
+`--terms` can't SUM — sum `gmv_num` (gross) or `net_num` (profit) client-side.
+Add `--terms marketplace` for a per-channel breakdown.
+
+**Everything that happened to one product (the lifecycle thread):**
+```bash
+python3 .../graylog_query.py --all -q 'product_id:"1729..."' \
+  --fields source,creator,sample_status,gmv_num,sample_status_json,sample_sold_json
+```
+This stitches the sample's status changes and its sale alongside the scraper
+sources (videos/lives) that share the same `product_id` + `creator`.
+
+Full field/query reference: [references/lifecycle-events.md](references/lifecycle-events.md).
+
+## Guardrails
+
+- **Write-only.** This skill never reads/aggregates — that's `graylog-query`.
+- **Never fake success.** A Graylog write can fail silently (the API returns
+  `graylog:false`); always reflect what actually persisted.
+- **Confirm the creator.** Don't attribute revenue to an unconfirmed handle.
+- **Writes hit production.** The endpoints are open (no auth, by design) and
+  `THIRSTY_API_URL` defaults to `https://thirsty.store`. Treat status/sold
+  writes as real inventory changes; confirm ambiguous targets before writing.
+- **Join key is `product_id` = `qr_code`.** A `qr_code` holding a barcode (not a
+  real TikTok productId) still works for status/sold, but won't join to scraper
+  content. `sample_id` is stamped on every event as the reconciliation fallback.

--- a/.claude/skills/sample-lifecycle/references/lifecycle-events.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-events.md
@@ -1,0 +1,104 @@
+# Sample-lifecycle Graylog events
+
+The two events this skill writes, and how `graylog-query` reads them back. Both
+are emitted by `core/lifecycle.ts` via `sendGelfMessage()` (defined in
+`core/graylog.ts`), which sends GELF `version:"1.1"`, `host:"thirsty-store-kiosk"`,
+single-`_`-prefixes every field, and drops empty/null values. Graylog strips the
+leading underscore, so a field written as `_sample_status` is queried as
+`sample_status`.
+
+Design: one JSON-string **container** field per event (lossless round-trip, like
+the existing `sample_edit_json`) **plus** flat scalar fields so queries can
+filter/range/`--terms` without parsing JSON.
+
+Join key across every stage: **`product_id`** (the sample's `qr_code`). The
+Postgres **`sample_id`** is stamped alongside as a reconciliation fallback.
+
+## Event 1 — status change
+
+`short_message`: `thirsty sample status: <name>`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sample_status_json` | JSON string | `{productId, sampleId, status, previousStatus, qrCode, name, source, note?, updatedAt}` |
+| `sample_status` | string | flat, filterable — e.g. `sample_status:cleared_to_sell` |
+| `product_id` | string | join key (= `qr_code`) |
+| `sample_id` | string | Postgres id (when a row matched) |
+| `sample_source` | string | `skill` (who wrote it) |
+
+Status is one of `available`, `checked_out`, `reserved`, `cleared_to_sell`,
+`discontinued` (`sold` is rejected — it goes through Event 2).
+
+## Event 2 — sold / resale revenue
+
+`short_message`: `thirsty sample sold: <name> $<price> via <marketplace> → <creator>`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sample_sold_json` | JSON string | `{productId, sampleId, name, creator, marketplace, salePrice, fees, shipping, costBasis, net, buyer?, orderRef?, soldAt, note?}` |
+| `creator` | string | attribution handle — same field/convention the scraper sources use |
+| `gmv_num` | number | **gross** sale price (matches affiliate-export `gmv_num`, so existing revenue recipes sum it) |
+| `sale_price_num` | number | alias of gross (explicit) |
+| `fee_num` / `shipping_num` / `cost_num` | number | the deductions |
+| `net_num` | number | `salePrice − fees − shipping − costBasis` |
+| `marketplace` | string | `ebay` / `offerup` / `fbmarketplace` / … |
+| `product_id` | string | join key |
+| `sample_id` | string | Postgres id |
+| `sample_status` | string | `sold` |
+| `sample_source` | string | `skill-resale` |
+
+Note: affiliate-export's `creator` is an *agency label*, but these resale events
+are authored by the skill, so the real `@handle` is stamped directly — resale
+revenue attributes more cleanly than affiliate data.
+
+## Read-back recipes (`graylog-query`)
+
+`--terms` only counts; it can't SUM — fetch rows and sum the `*_num` field
+client-side. Match handles with both forms: `(creator:"@x" OR creator.keyword:"@x")`.
+
+**All resale sales (any creator), newest first:**
+```bash
+python3 .../graylog_query.py --all -q 'sample_sold_json:*' \
+  --fields creator,product_id,marketplace,gmv_num,net_num --sort timestamp:desc
+```
+
+**One creator's resale revenue, by marketplace:**
+```bash
+python3 .../graylog_query.py --all \
+  -q '(creator:"@wizardofdealz" OR creator.keyword:"@wizardofdealz") AND sample_sold_json:*' \
+  --terms marketplace
+# then fetch rows and sum gmv_num (gross) / net_num (profit)
+```
+
+**High-value resales this quarter:**
+```bash
+python3 .../graylog_query.py --last 90d \
+  -q 'sample_sold_json:* AND gmv_num:[50 TO *]' \
+  --fields creator,product_id,marketplace,gmv_num,net_num --sort gmv_num:desc
+```
+
+**Status history of one sample/product:**
+```bash
+python3 .../graylog_query.py --all -q 'product_id:"1729..." AND sample_status_json:*' \
+  --fields sample_status,sample_status_json --sort timestamp:desc
+```
+
+**Full lifecycle thread for a product** — status + sale + the scraper content
+(videos/lives) that share the same `product_id`/`creator`:
+```bash
+python3 .../graylog_query.py --all -q 'product_id:"1729..."' \
+  --fields source,creator,sample_status,gmv_num,sample_status_json,sample_sold_json
+```
+
+## Lifecycle join — current reach and the gap
+
+`product_id` links: **intake** (`samples.qr_code`) → **status changes**
+(Event 1) → **content** (`source:tiktok-bookmarklet-product-analysis` etc.,
+which carry `Product ID` + `creator`) → **resale** (Event 2).
+
+The weak link is **order-received** (`source:tiktok-bookmarklet-orders`): those
+scrape events carry neither `product_id` nor `creator` (product is matched by
+name only), so "order received → which content sold it" can't be joined
+automatically yet. Closing that needs the order scraper to capture a productId —
+out of scope for this skill. Until then, that hop is matched manually by product
+name against the catalog (`/api/products`).

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "thirsty-samples": {
+      "command": "deno",
+      "args": [
+        "run",
+        "-A",
+        "--config",
+        "mcp/thirsty-samples/deno.json",
+        "mcp/thirsty-samples/server.ts"
+      ],
+      "env": {
+        "THIRSTY_API_URL": "https://thirsty.store"
+      }
+    }
+  }
+}

--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -230,6 +230,48 @@ export async function fetchSampleEditRecords(
   }
 }
 
+// Distinct creator handles seen anywhere in Graylog. Every scraper source and
+// our own resale events (sample_sold_json) carry a `creator` field, so a single
+// `creator:*` sweep enumerates them. Backs the sample-lifecycle skill's live
+// attribution list (the user opted to derive creators from Graylog rather than
+// maintain a static allow-list) and mirrors graylog-query's `--terms creator`.
+// Widened to ~5y because creator activity is bursty and a 30d window routinely
+// misses real handles. Real @-handles sort first; bare agency labels (which
+// affiliate-export mirrors into `creator`) follow.
+export async function fetchKnownCreators(limit = 1000): Promise<string[]> {
+  const config = graylogConfigFromEnv();
+  if (!config) return [];
+
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 1000;
+
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365 * 5,
+    };
+    const messages = await searchGraylog(
+      wide,
+      "creator:*",
+      Math.max(200, Math.min(safeLimit, 1000)),
+      ["timestamp", "creator"],
+    );
+    const seen = new Set<string>();
+    for (const message of messages) {
+      const creator = typeof message.creator === "string"
+        ? message.creator.trim()
+        : "";
+      if (creator) seen.add(creator);
+    }
+    return [...seen].sort((a, b) => {
+      const aRank = a.startsWith("@") ? 0 : 1;
+      const bRank = b.startsWith("@") ? 0 : 1;
+      return aRank - bRank || a.localeCompare(b);
+    });
+  } catch {
+    return [];
+  }
+}
+
 export function graylogConfigFromEnv(): GraylogConfig | null {
   const url = normalizeGraylogUrl(
     envValue("GRAYLOG_API_URL") || envValue("GRAYLOG_URL"),

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -1,0 +1,459 @@
+// Sample lifecycle write path: status changes and resale ("sold") events.
+//
+// Two write targets per the design decisions:
+//   1. Postgres (`public.samples` + `inventory_transactions`) — the inventory
+//      source of truth, shared with the tiktok-sample-tracker app. Reached via
+//      the same db.ts helpers main.ts already uses.
+//   2. Graylog — the durable analytics spine. Each event mirrors the proven
+//      `sample_edit_json` pattern from core/samples.ts: one JSON-string
+//      container field (lossless round-trip) plus flat scalar fields so the
+//      read-side `graylog-query` skill can filter/range/aggregate without
+//      parsing JSON. sendGelfMessage() strips empties and single-underscore-
+//      prefixes every field, so `sample_status` is queryable as `sample_status`.
+//
+// The resale event deliberately reuses graylog-query's revenue vocabulary —
+// `creator` + `gmv_num` (gross) — so a creator's resale revenue is queryable
+// the moment it's written, with no change to that skill. `net_num` (and the
+// fee/shipping/cost breakdown) are additive for profit views.
+//
+// Join key across the whole lifecycle is the TikTok productId, which is the
+// sample's `qr_code` in Postgres (see sampleRowToKioskProduct in main.ts) and
+// `product_id` on Graylog events. `sample_id` is stamped alongside so the two
+// systems reconcile even when a qr_code holds a barcode instead of a real id.
+
+import { sendGelfMessage } from "./graylog.ts";
+import { InventoryTransactions, Samples } from "../db.ts";
+import sampleStatuses from "./sample-statuses.json" with { type: "json" };
+
+export type SampleStatusEntry = {
+  value: string;
+  label: string;
+  kind: "status" | "badge";
+  exclusive: boolean;
+  appliesTo: string[];
+  icon: string | null;
+  palette: string;
+  order: number;
+};
+
+type SampleRow = Record<string, unknown>;
+
+export type SampleRef = {
+  sampleId?: string | number;
+  productId?: string;
+  qrCode?: string;
+};
+
+export type StatusUpdateInput = SampleRef & {
+  status?: string;
+  note?: string;
+  source?: string;
+  operator?: string;
+};
+
+export type StatusUpdateResult = {
+  ok: boolean;
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  status: string;
+  previousStatus: string | null;
+  postgres: { updated: boolean; reason?: string };
+  graylog: boolean;
+  message: string;
+};
+
+export type SoldInput = SampleRef & {
+  creator?: string;
+  salePrice?: number | string;
+  marketplace?: string;
+  fees?: number | string;
+  shipping?: number | string;
+  costBasis?: number | string;
+  buyer?: string;
+  orderRef?: string;
+  note?: string;
+  operator?: string;
+  // Re-sell an already-sold sample on purpose (re-attribution). Off by default
+  // because the Graylog revenue total can't be un-inflated — see the guard.
+  force?: boolean;
+};
+
+export type SoldResult = {
+  ok: boolean;
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  creator: string;
+  marketplace: string;
+  salePrice: number;
+  fees: number;
+  shipping: number;
+  costBasis: number;
+  net: number;
+  postgres: { updated: boolean; transactionId: number | null; reason?: string };
+  graylog: boolean;
+  message: string;
+};
+
+const STATUSES = sampleStatuses as SampleStatusEntry[];
+
+// The full synced status vocabulary (statuses + badges) — served verbatim so the
+// MCP/skill validate against the same single source the tracker uses.
+export function listSampleStatuses(): SampleStatusEntry[] {
+  return STATUSES;
+}
+
+// Only `kind:"status"` values can live in the single `samples.status` column;
+// badges (fire_sale, lowest_price) are non-exclusive and tracked elsewhere.
+function statusValues(): string[] {
+  return STATUSES.filter((entry) => entry.kind === "status").map((e) => e.value);
+}
+
+function isStatusValue(value: string): boolean {
+  return statusValues().includes(value);
+}
+
+// Resolve a sample by explicit id, else by productId/qr_code. A qr_code can be
+// shared by several physical samples of one product, so when resolving by that
+// key for a sale we prefer a not-yet-sold row (newest first).
+async function resolveSampleRow(
+  ref: SampleRef,
+  opts: { preferUnsold?: boolean } = {},
+): Promise<SampleRow | null> {
+  const id = String(ref.sampleId ?? "").trim();
+  if (id) {
+    const rows = await Samples.filter({ id }, undefined, 1) as SampleRow[];
+    if (rows[0]) return rows[0];
+  }
+
+  const key = String(ref.productId ?? ref.qrCode ?? "").trim();
+  if (key) {
+    const rows = await Samples.filter(
+      { qr_code: key },
+      "-created_at",
+      25,
+    ) as SampleRow[];
+    if (!rows.length) return null;
+    if (opts.preferUnsold) {
+      const unsold = rows.find((r) => String(r.status ?? "").trim() !== "sold");
+      return unsold ?? rows[0];
+    }
+    return rows[0];
+  }
+
+  return null;
+}
+
+function productIdOf(row: SampleRow | null, ref: SampleRef): string | null {
+  if (row) {
+    const fromRow = String(row.qr_code ?? "").trim();
+    if (fromRow) return fromRow;
+  }
+  const fromRef = String(ref.productId ?? ref.qrCode ?? "").trim();
+  return fromRef || null;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const n = Number(value.replace(/[$,]/g, ""));
+    if (Number.isFinite(n)) return n;
+  }
+  return NaN;
+}
+
+function numOrZero(value: unknown): number {
+  const n = toNumber(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+// Update a sample's exclusive status (available / checked_out / reserved /
+// cleared_to_sell / discontinued). `sold` is rejected on purpose: it must go
+// through the sold flow so resale revenue is attributed to a creator. Patches
+// Postgres when a row matches, and always emits a Graylog status event so the
+// change is recoverable/queryable even if the row is Graylog-only.
+export async function recordSampleStatus(
+  input: StatusUpdateInput,
+): Promise<StatusUpdateResult> {
+  const status = String(input.status || "").trim();
+  if (!status) throw new Error("status is required");
+  if (!isStatusValue(status)) {
+    throw new Error(
+      `Unknown status "${status}". Valid statuses: ${statusValues().join(", ")}`,
+    );
+  }
+  if (status === "sold") {
+    throw new Error(
+      "Use the sold flow (mark_sample_sold / POST /api/sample-sold) to mark a " +
+        "sample sold, so the resale revenue is attributed to a creator account.",
+    );
+  }
+
+  const row = await resolveSampleRow(input);
+  const sampleId = row ? Number(row.id) : null;
+  const productId = productIdOf(row, input);
+  const name = row ? String(row.name ?? "").trim() || null : null;
+  const previousStatus = row ? String(row.status ?? "").trim() || null : null;
+  const now = new Date().toISOString();
+  const source = String(input.source || "skill").trim() || "skill";
+  const note = String(input.note || "").trim();
+
+  let updated = false;
+  let reason: string | undefined;
+  if (row) {
+    try {
+      await Samples.update(String(row.id), { status });
+      updated = true;
+    } catch (error) {
+      reason = error instanceof Error ? error.message : String(error);
+    }
+  } else {
+    reason = "no matching sample row in Postgres (Graylog event still written)";
+  }
+
+  const graylog = await sendGelfMessage(
+    `thirsty sample status: ${name ?? productId ?? "unknown"}`,
+    {
+      sample_status_json: JSON.stringify({
+        productId,
+        sampleId,
+        status,
+        previousStatus,
+        qrCode: productId,
+        name,
+        source,
+        note: note || undefined,
+        updatedAt: now,
+      }),
+      sample_status: status,
+      product_id: productId ?? undefined,
+      sample_id: sampleId != null ? String(sampleId) : undefined,
+      sample_source: source,
+    },
+  );
+
+  return {
+    ok: updated || graylog,
+    sampleId,
+    productId,
+    name,
+    status,
+    previousStatus,
+    postgres: { updated, reason },
+    graylog,
+    message: describe("status", {
+      updated,
+      graylog,
+      name,
+      productId,
+      status,
+      warnings: graylog ? [] : ["Graylog event was NOT written"],
+    }),
+  };
+}
+
+// Mark a sample sold and attribute the resale revenue to a creator. Writes the
+// inventory truth to Postgres (status=sold + sale columns + a `sold` transaction)
+// and the analytics event to Graylog. `creator`, `salePrice`, and `marketplace`
+// are required; fees/shipping/costBasis are optional and feed the computed net.
+export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
+  const creator = String(input.creator || "").trim();
+  if (!creator) {
+    throw new Error(
+      "creator is required — which creator account should this resale revenue " +
+        "be attributed to?",
+    );
+  }
+  const salePrice = toNumber(input.salePrice);
+  if (!(salePrice > 0)) {
+    throw new Error("salePrice must be a positive number");
+  }
+  const marketplace = String(input.marketplace || "").trim();
+  if (!marketplace) {
+    throw new Error(
+      "marketplace is required (e.g. ebay, offerup, fbmarketplace)",
+    );
+  }
+
+  const fees = numOrZero(input.fees);
+  const shipping = numOrZero(input.shipping);
+  const costBasis = numOrZero(input.costBasis);
+  const net = round2(salePrice - fees - shipping - costBasis);
+
+  const row = await resolveSampleRow(input, { preferUnsold: true });
+  const sampleId = row ? Number(row.id) : null;
+  const productId = productIdOf(row, input);
+  const name = row ? String(row.name ?? "").trim() || null : null;
+  const previousStatus = row ? String(row.status ?? "").trim() || null : null;
+
+  // Guard against double-selling. GELF revenue events are append-only and the
+  // read side sums `gmv_num` client-side, so a second sale permanently inflates
+  // the creator's attributed revenue — the Postgres overwrite self-heals, the
+  // analytics total can't. Refuse unless the caller explicitly re-attributes.
+  if (previousStatus === "sold" && input.force !== true) {
+    const soldAt = row ? String(row.sold_at ?? "").trim() : "";
+    throw new Error(
+      `Sample ${row?.id ?? productId ?? "?"} is already sold${
+        soldAt ? ` (sold_at=${soldAt})` : ""
+      } — re-attributing would double-count the creator's resale revenue. Pass ` +
+        "force:true to override.",
+    );
+  }
+
+  const now = new Date().toISOString();
+  const buyer = String(input.buyer || "").trim();
+  const orderRef = String(input.orderRef || "").trim();
+  const note = String(input.note || "").trim();
+  const operator = String(input.operator || "").trim();
+
+  let updated = false;
+  let transactionId: number | null = null;
+  const reasons: string[] = [];
+  if (row) {
+    try {
+      await Samples.update(String(row.id), {
+        status: "sold",
+        sold_price: salePrice,
+        sold_at: now,
+        sold_to: buyer || null,
+      });
+      updated = true;
+    } catch (error) {
+      reasons.push(error instanceof Error ? error.message : String(error));
+    }
+    try {
+      const summary = `Resale via ${marketplace} → ${creator} | gross $${
+        salePrice.toFixed(2)
+      }${net !== salePrice ? ` | net $${net.toFixed(2)}` : ""}${
+        note ? ` | ${note}` : ""
+      }`;
+      const tx = await InventoryTransactions.create({
+        action: "sold",
+        sample_id: row.id,
+        checked_out_to: buyer || null,
+        operator: operator || null,
+        scanned_code: productId || null,
+        notes: summary,
+      }) as SampleRow | undefined;
+      transactionId = tx && tx.id != null ? Number(tx.id) : null;
+    } catch (error) {
+      reasons.push(
+        `transaction: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  } else {
+    reasons.push("no matching sample row in Postgres (Graylog event still written)");
+  }
+
+  const graylog = await sendGelfMessage(
+    `thirsty sample sold: ${name ?? productId ?? "sample"} $${
+      salePrice.toFixed(2)
+    } via ${marketplace} → ${creator}`,
+    {
+      sample_sold_json: JSON.stringify({
+        productId,
+        sampleId,
+        name,
+        creator,
+        marketplace,
+        salePrice,
+        fees,
+        shipping,
+        costBasis,
+        net,
+        buyer: buyer || undefined,
+        orderRef: orderRef || undefined,
+        soldAt: now,
+        note: note || undefined,
+      }),
+      creator,
+      gmv_num: salePrice,
+      sale_price_num: salePrice,
+      fee_num: fees,
+      shipping_num: shipping,
+      cost_num: costBasis,
+      net_num: net,
+      marketplace,
+      product_id: productId ?? undefined,
+      sample_id: sampleId != null ? String(sampleId) : undefined,
+      sample_status: "sold",
+      sample_source: "skill-resale",
+    },
+  );
+
+  // Honest headline: the sample UPDATE and the audit-transaction INSERT can
+  // fail independently, and the GELF write can fail silently — surface each.
+  const warnings: string[] = [];
+  if (!graylog) warnings.push("Graylog revenue event was NOT written");
+  if (updated && transactionId === null) {
+    warnings.push("the inventory audit transaction was NOT recorded");
+  }
+
+  return {
+    ok: updated || graylog,
+    sampleId,
+    productId,
+    name,
+    creator,
+    marketplace,
+    salePrice,
+    fees,
+    shipping,
+    costBasis,
+    net,
+    postgres: {
+      updated,
+      transactionId,
+      reason: reasons.length ? reasons.join("; ") : undefined,
+    },
+    graylog,
+    message: describe("sold", {
+      updated,
+      graylog,
+      name,
+      productId,
+      creator,
+      salePrice,
+      marketplace,
+      warnings,
+    }),
+  };
+}
+
+// Human-readable outcome line. Honest about partial success: a Graylog write can
+// silently fail (sendGelfMessage returns false), so we never report success that
+// didn't happen.
+function describe(
+  kind: "status" | "sold",
+  o: {
+    updated: boolean;
+    graylog: boolean;
+    name: string | null;
+    productId: string | null;
+    status?: string;
+    creator?: string;
+    salePrice?: number;
+    marketplace?: string;
+    warnings?: string[];
+  },
+): string {
+  const label = o.name ?? o.productId ?? "sample";
+  const targets: string[] = [];
+  if (o.updated) targets.push("Postgres");
+  if (o.graylog) targets.push("Graylog");
+  const where = targets.length ? targets.join(" + ") : "nothing";
+
+  const base = kind === "status"
+    ? `Set ${label} to "${o.status}" (persisted to ${where}).`
+    : `Sold ${label} for $${(o.salePrice ?? 0).toFixed(2)} via ${
+      o.marketplace
+    }, attributed to ${o.creator} (persisted to ${where}).`;
+
+  const warnings = o.warnings ?? [];
+  return warnings.length ? `${base} WARNING: ${warnings.join("; ")}.` : base;
+}

--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,16 @@ import {
   updateSamplePrice,
   upsertSampleProduct,
 } from "./core/samples.ts";
-import { envValue, graylogConfigFromEnv } from "./core/graylog.ts";
+import {
+  listSampleStatuses,
+  recordSampleSold,
+  recordSampleStatus,
+} from "./core/lifecycle.ts";
+import {
+  envValue,
+  fetchKnownCreators,
+  graylogConfigFromEnv,
+} from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
 
 const pool = new Pool({
@@ -872,6 +881,52 @@ export async function legacyHandler(req: Request): Promise<Response> {
 
       if (pathname === "/api/sample-valuation") {
         return json(await fetchSampleValuationWithEdits());
+      }
+
+      // ---- Sample lifecycle (status changes + resale revenue) ----
+      // Backs the sample-lifecycle skill / thirsty-samples MCP. Writes inventory
+      // truth to Postgres AND an analytics event to Graylog (see core/lifecycle.ts).
+      // Open like the sibling sample/transaction writes — no auth gate by design.
+
+      // The synced status vocabulary, so callers validate against one source.
+      if (pathname === "/api/sample-statuses") {
+        return json(listSampleStatuses());
+      }
+
+      // Distinct creator handles seen in Graylog — the live attribution list for
+      // the sold flow (mirrors graylog-query's `--terms creator`).
+      if (pathname === "/api/creators") {
+        const raw = Number(url.searchParams.get("limit"));
+        const limit = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 1000;
+        return json({ creators: await fetchKnownCreators(limit) });
+      }
+
+      // Update a sample's status (rejects "sold" — that goes through the sold
+      // flow so revenue is attributed to a creator). Validation failures return
+      // a clean 400 (not the outer 500 + stack) so the MCP surfaces the reason.
+      if (pathname === "/api/sample-status") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordSampleStatus(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // Mark a sample sold and attribute the resale revenue to a creator.
+      if (pathname === "/api/sample-sold") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordSampleSold(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
       }
 
       // Kiosk-fleet heartbeat (in-memory; powers the dashboard's Fleet panel).

--- a/mcp/thirsty-samples/README.md
+++ b/mcp/thirsty-samples/README.md
@@ -1,0 +1,53 @@
+# thirsty-samples MCP server
+
+A thin [MCP](https://modelcontextprotocol.io) stdio server that exposes
+data-pimp's sample-lifecycle HTTP API as tools. It holds no Graylog/Postgres
+logic of its own — every tool calls data-pimp (default `https://thirsty.store`),
+which writes inventory truth to Postgres **and** an analytics event to Graylog
+(see [`core/lifecycle.ts`](../../core/lifecycle.ts)).
+
+Paired with the [`sample-lifecycle`](../../.claude/skills/sample-lifecycle/SKILL.md)
+skill, which documents how to drive these tools (status updates + sold-with-
+creator-attribution) and how to read the revenue back via the `graylog-query`
+skill.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_samples` | Find a sample by name/brand/productId → resolve its `id`. |
+| `list_sample_statuses` | The synced status vocabulary (validate before writing). |
+| `list_creators` | Creator handles seen live in Graylog (attribution list). |
+| `update_sample_status` | Set a sample's status (rejects `sold`). |
+| `mark_sample_sold` | Mark sold + attribute resale revenue to a creator. |
+
+## Run
+
+Registered for Claude Code via [`.mcp.json`](../../.mcp.json) at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "thirsty-samples": {
+      "command": "deno",
+      "args": ["run", "-A", "mcp/thirsty-samples/server.ts"],
+      "env": { "THIRSTY_API_URL": "https://thirsty.store" }
+    }
+  }
+}
+```
+
+Runs on Deno (the repo runtime) — no `npm install` or build step; Deno fetches
+the SDK from the pinned `npm:@modelcontextprotocol/sdk@1.29.0` specifier on first
+run. Point `THIRSTY_API_URL` at a local data-pimp (`http://localhost:8000`) to
+test against a dev DB/Graylog instead of production.
+
+Smoke-test the handshake without a client:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | deno run -A mcp/thirsty-samples/server.ts
+```

--- a/mcp/thirsty-samples/deno.json
+++ b/mcp/thirsty-samples/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "start": "deno run -A server.ts"
+  }
+}

--- a/mcp/thirsty-samples/deno.lock
+++ b/mcp/thirsty-samples/deno.lock
@@ -1,0 +1,523 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@modelcontextprotocol/sdk@1.29.0": "1.29.0_zod@4.3.6"
+  },
+  "npm": {
+    "@hono/node-server@1.19.14_hono@4.12.27": {
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@4.3.6": {
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type@1.0.5",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.20.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.20.0": {
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
+    "body-parser@2.3.0": {
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dependencies": [
+        "bytes",
+        "content-type@2.0.0",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
+    },
+    "content-disposition@1.1.0": {
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "content-type@2.0.0": {
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.1.0": {
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.5.2_express@5.2.1": {
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type@1.0.5",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.2": {
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hono@4.12.27": {
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="
+    },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address@10.2.0": {
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.3": {
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
+    },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.4.2": {
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.3": {
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": [
+        "es-define-property",
+        "side-channel"
+      ]
+    },
+    "range-parser@1.3.0": {
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
+    },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.1": {
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.1": {
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "type-is@2.1.0": {
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dependencies": [
+        "content-type@2.0.0",
+        "media-typer",
+        "mime-types"
+      ]
+    },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
+    },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "zod-to-json-schema@3.25.2_zod@4.3.6": {
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    }
+  }
+}

--- a/mcp/thirsty-samples/server.ts
+++ b/mcp/thirsty-samples/server.ts
@@ -1,0 +1,320 @@
+// thirsty-samples — MCP server for the sample lifecycle.
+//
+// Thin stdio server that exposes the data-pimp sample-lifecycle HTTP API as MCP
+// tools. It owns no Graylog/Postgres logic: every tool is a call to data-pimp
+// (default https://thirsty.store), which writes the inventory truth to Postgres
+// and the analytics event to Graylog (see core/lifecycle.ts). Runs on Deno —
+// matching the repo runtime — so there's no npm install or build step; Deno
+// fetches the SDK from the npm: specifier on first run.
+//
+// Tools:
+//   list_samples         — find samples by name/brand/productId (resolve an id)
+//   list_sample_statuses — the synced status vocabulary (validate before write)
+//   list_creators        — creator handles seen in Graylog (attribution list)
+//   update_sample_status — set a sample's status (rejects "sold")
+//   mark_sample_sold     — mark sold + attribute resale revenue to a creator
+//
+// Env: THIRSTY_API_URL (or THIRSTY_API) overrides the API base.
+
+import { Server } from "npm:@modelcontextprotocol/sdk@1.29.0/server/index.js";
+import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk@1.29.0/server/stdio.js";
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "npm:@modelcontextprotocol/sdk@1.29.0/types.js";
+
+const BASE = (Deno.env.get("THIRSTY_API_URL") || Deno.env.get("THIRSTY_API") ||
+  "https://thirsty.store").replace(/\/+$/, "");
+
+// One JSON fetch helper. Surfaces the API's own error message (data-pimp returns
+// { error } / { ok:false, error }) rather than a bare status code.
+async function api(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<unknown> {
+  const hasBody = init?.body !== undefined;
+  const res = await fetch(`${BASE}${path}`, {
+    method: init?.method ?? "GET",
+    headers: {
+      accept: "application/json",
+      ...(hasBody ? { "content-type": "application/json" } : {}),
+    },
+    body: hasBody ? JSON.stringify(init!.body) : undefined,
+  });
+
+  const text = await res.text();
+  let data: unknown = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+
+  if (!res.ok) {
+    const msg = data && typeof data === "object"
+      ? (data as Record<string, unknown>).error ??
+        (data as Record<string, unknown>).message ?? `HTTP ${res.status}`
+      : `HTTP ${res.status}`;
+    throw new Error(`${init?.method ?? "GET"} ${path} failed: ${msg}`);
+  }
+  return data;
+}
+
+function asString(v: unknown): string | null {
+  if (typeof v === "string") return v;
+  if (typeof v === "number") return String(v);
+  return null;
+}
+
+// Project a raw Postgres samples row down to the fields the model needs to pick
+// one and act on it. productId is the qr_code (the cross-lifecycle join key).
+function slimSample(row: Record<string, unknown>) {
+  return {
+    id: row.id ?? null,
+    name: asString(row.name),
+    brand: asString(row.brand),
+    productId: asString(row.qr_code),
+    status: asString(row.status),
+    currentPrice: row.current_price ?? null,
+    soldPrice: row.sold_price ?? null,
+    soldAt: asString(row.sold_at),
+    soldTo: asString(row.sold_to),
+  };
+}
+
+const TOOLS = [
+  {
+    name: "list_samples",
+    description:
+      "Find samples in the LP Sample Tracker (Postgres) by name, brand, or " +
+      "productId/qr_code, so you can resolve which sample to act on. Returns " +
+      "id, name, brand, productId, status, and sale details. Use the returned " +
+      "id with update_sample_status / mark_sample_sold.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "Case-insensitive substring matched against name, brand, " +
+            "productId/qr_code, and id. Omit to list recent samples.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Max samples to return after filtering (default 25). Filtering is " +
+            "client-side over all samples.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_sample_statuses",
+    description:
+      "The synced sample-status vocabulary (the single source the tracker " +
+      "uses). Validate a target status against this before update_sample_status. " +
+      "Only kind:'status' values go in a sample's status; 'sold' must go " +
+      "through mark_sample_sold.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "list_creators",
+    description:
+      "Creator handles seen live in Graylog (scraper sources + prior resale " +
+      "events) — the attribution list for mark_sample_sold. Real @-handles " +
+      "sort first. Mirrors graylog-query's `--terms creator`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Max handles (default 1000)." },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "update_sample_status",
+    description:
+      "Set a sample's status (available / checked_out / reserved / " +
+      "cleared_to_sell / discontinued). Writes Postgres + a Graylog status " +
+      "event. Rejects 'sold' — use mark_sample_sold so revenue is attributed " +
+      "to a creator. Identify the sample by sampleId (preferred) or productId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sampleId: {
+          type: ["string", "number"],
+          description: "The sample's Postgres id (from list_samples).",
+        },
+        productId: {
+          type: "string",
+          description:
+            "The TikTok productId / qr_code. Used if sampleId is omitted; " +
+            "may match multiple physical samples.",
+        },
+        status: {
+          type: "string",
+          description:
+            "Target status. Must be a kind:'status' value from " +
+            "list_sample_statuses (not 'sold').",
+        },
+        note: { type: "string", description: "Optional note recorded on the event." },
+      },
+      required: ["status"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "mark_sample_sold",
+    description:
+      "Mark a sample sold and attribute the resale revenue to a creator " +
+      "account. Writes the inventory truth to Postgres (status=sold + sale " +
+      "columns + a 'sold' transaction) and a Graylog revenue event " +
+      "(creator + gmv_num gross + net_num) that the graylog-query skill can " +
+      "read per-creator. ALWAYS confirm which creator to attribute to before " +
+      "calling. Identify the sample by sampleId (preferred) or productId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sampleId: { type: ["string", "number"], description: "Sample's Postgres id." },
+        productId: {
+          type: "string",
+          description: "TikTok productId / qr_code (used if sampleId omitted).",
+        },
+        creator: {
+          type: "string",
+          description:
+            "Creator @handle to attribute revenue to (validate against " +
+            "list_creators).",
+        },
+        salePrice: {
+          type: ["number", "string"],
+          description: "Gross sale price (recorded as gmv_num).",
+        },
+        marketplace: {
+          type: "string",
+          description: "Where it sold: ebay, offerup, fbmarketplace, etc.",
+        },
+        fees: { type: ["number", "string"], description: "Marketplace fees (optional)." },
+        shipping: { type: ["number", "string"], description: "Shipping cost (optional)." },
+        costBasis: {
+          type: ["number", "string"],
+          description: "Cost basis of the sample (optional). net = sale - fees - shipping - cost.",
+        },
+        buyer: { type: "string", description: "Optional buyer (stored as sold_to)." },
+        orderRef: { type: "string", description: "Optional marketplace order/listing ref." },
+        note: { type: "string", description: "Optional note." },
+        force: {
+          type: "boolean",
+          description:
+            "Re-attribute an already-sold sample on purpose (default false). " +
+            "Without it, selling an already-sold sample is refused to avoid " +
+            "double-counting the creator's revenue.",
+        },
+      },
+      required: ["creator", "salePrice", "marketplace"],
+      additionalProperties: false,
+    },
+  },
+];
+
+const server = new Server(
+  { name: "thirsty-samples", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  const name = request.params.name;
+  const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+
+  try {
+    let result: unknown;
+
+    switch (name) {
+      case "list_samples": {
+        const rows = (await api("/api/samples")) as Record<string, unknown>[];
+        const list = Array.isArray(rows) ? rows : [];
+        const q = String(args.query ?? "").trim().toLowerCase();
+        const limit = Number(args.limit) > 0 ? Math.trunc(Number(args.limit)) : 25;
+        const filtered = q
+          ? list.filter((r) =>
+            [r.name, r.brand, r.qr_code, r.id]
+              .map((v) => String(v ?? "").toLowerCase())
+              .some((s) => s.includes(q))
+          )
+          : list;
+        result = {
+          count: filtered.length,
+          samples: filtered.slice(0, limit).map(slimSample),
+        };
+        break;
+      }
+
+      case "list_sample_statuses": {
+        result = await api("/api/sample-statuses");
+        break;
+      }
+
+      case "list_creators": {
+        const limit = Number(args.limit) > 0 ? Math.trunc(Number(args.limit)) : 1000;
+        result = await api(`/api/creators?limit=${limit}`);
+        break;
+      }
+
+      case "update_sample_status": {
+        result = await api("/api/sample-status", {
+          method: "POST",
+          body: {
+            sampleId: args.sampleId,
+            productId: args.productId,
+            status: args.status,
+            note: args.note,
+            source: "skill",
+          },
+        });
+        break;
+      }
+
+      case "mark_sample_sold": {
+        result = await api("/api/sample-sold", {
+          method: "POST",
+          body: {
+            sampleId: args.sampleId,
+            productId: args.productId,
+            creator: args.creator,
+            salePrice: args.salePrice,
+            marketplace: args.marketplace,
+            fees: args.fees,
+            shipping: args.shipping,
+            costBasis: args.costBasis,
+            buyer: args.buyer,
+            orderRef: args.orderRef,
+            note: args.note,
+            force: args.force,
+          },
+        });
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${msg}` }],
+      isError: true,
+    };
+  }
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error(`[thirsty-samples] MCP server ready (API base: ${BASE})`);


### PR DESCRIPTION
## What

Adds a **`sample-lifecycle` skill** + **`thirsty-samples` MCP server** + supporting endpoints so you can, in natural language, **update a sample's status** or **mark a sample SOLD and attribute the resale revenue to a creator** — and have that revenue immediately queryable by the existing `graylog-query` skill.

## How it's wired

Each action **dual-writes**:
- **Postgres** (`public.samples` + `inventory_transactions`) — the inventory source of truth, via the existing `db.ts` helpers.
- **Graylog** — a durable GELF analytics event via `sendGelfMessage`, mirroring the proven `sample_edit_json` pattern.

The SOLD event deliberately reuses `graylog-query`'s own revenue vocabulary — flat `creator` + `gmv_num` (gross) + `net_num` (profit) + `marketplace` — so a creator's resale revenue is queryable the instant it's written, **with zero changes to that skill**. Join key across the lifecycle is `product_id` (= `samples.qr_code`); `sample_id` is stamped as a reconciliation fallback.

### New code
- `core/lifecycle.ts` — `recordSampleStatus`, `recordSampleSold` (validates status, rejects `sold` from the status path, computes `net`, guards against double-selling).
- `core/graylog.ts` — `fetchKnownCreators()` (live `creator:*` sweep for the attribution list).
- `main.ts` — `GET /api/sample-statuses`, `GET /api/creators`, `POST /api/sample-status`, `POST /api/sample-sold` (open, matching existing `/api/*`; validation → clean 400s).
- `mcp/thirsty-samples/` — Deno MCP server (5 tools), isolated `deno.json`/`deno.lock` (pinned `@modelcontextprotocol/sdk@1.29.0`), registered via `.mcp.json`.
- `.claude/skills/sample-lifecycle/` — the skill + event-schema reference.

## Design decisions (confirmed)
- SOLD persists to **both** Postgres + Graylog.
- Creators **derived live from Graylog** (not a static list).
- Revenue captures **net** (fees/shipping/cost).
- Write endpoints **open** (no auth), matching existing `/api/*`.
- Re-selling an already-sold sample is **refused** unless `force:true` (Graylog events are append-only, so a double-sell would permanently inflate a creator's total).

## Verification
- `deno check` clean on all new code (the lone pre-existing barcode `TS2345` is untouched).
- MCP `initialize` + `tools/list` work via the exact registered command; all 5 tools listed.
- Live route tests: statuses/creators return correctly; validation guards return clean 400s; `?limit=abc` no longer crashes.
- Adversarial multi-agent review (find → verify → synthesize): all material findings fixed.

## Deploy / activate
1. **Deploy data-pimp** — the new `/api/sample-*` endpoints must reach `thirsty.store` (the MCP's default `THIRSTY_API_URL`).
2. **Reload Claude Code** to register the `thirsty-samples` MCP from `.mcp.json` (first run fetches the SDK via Deno).

## Out of scope (flagged)
- The order-received scraper (`tok-scrape-main/extension-seller/scrape-order.js`) captures no `productId`/creator — the one gap blocking fully-automatic intake→order→content→resale joins.
- The seller/streamer dashboards (`member/islands/*-data.ts`) are still hardcoded stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
