### PR TITLE
Add list_on_marketplace listing stub + lifecycle flow diagram

### DIFF
--- a/.claude/skills/sample-lifecycle/SKILL.md
+++ b/.claude/skills/sample-lifecycle/SKILL.md
@@ -4,14 +4,16 @@ description: >-
   Update a sample's status, or mark a sample SOLD and attribute the resale
   revenue to a creator account, in the LP Sample Tracker (thirsty.store /
   admin.thirsty.store). Trigger whenever the user wants to change a sample's
-  state or log a resale — e.g. "mark <product> as sold", "this sold on eBay for
-  $40", "set <product> to cleared to sell", "reserve sample 42", "discontinue
-  this one", "log a resale", "attribute this sale to @wizardofdealz". Each action
-  writes the inventory truth to Postgres AND a Graylog event, so a creator's
-  resale revenue is immediately queryable. For READ-ONLY questions about the data
-  ("how much resale revenue did @x make", "which samples sold this month", "what's
-  in Graylog") use the graylog-query skill instead — this skill only WRITES.
-allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__mark_sample_sold
+  state, list it for resale, or log a sale — e.g. "mark <product> as sold", "this
+  sold on eBay for $40", "set <product> to cleared to sell", "reserve sample 42",
+  "discontinue this one", "list this on eBay for $45", "I put it up on OfferUp",
+  "log a resale", "attribute this sale to @wizardofdealz". Each action writes a
+  Graylog event (and, for status/sold, the inventory truth to Postgres), so a
+  creator's listings and resale revenue are immediately queryable. For READ-ONLY
+  questions about the data ("how much resale revenue did @x make", "what's listed
+  where", "which samples sold this month", "what's in Graylog") use the
+  graylog-query skill instead — this skill only WRITES.
+allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__list_on_marketplace, mcp__thirsty-samples__mark_sample_sold
 ---
 
 # sample-lifecycle
@@ -36,7 +38,7 @@ what") is the `graylog-query` skill's job — see *Reading it back* below.
 2. **Validate the target status.** Call `list_sample_statuses` and confirm the
    requested status is one of the exclusive lifecycle statuses — `available`,
    `checked_out`, `reserved`, `cleared_to_sell`, `discontinued`. (`sold` is also
-   `kind:"status"` but is rejected here — route sales through Workflow 2.) Map
+   `kind:"status"` but is rejected here — route sales through Workflow 3.) Map
    the user's words to the canonical `value` (e.g. "clear it to sell" →
    `cleared_to_sell`).
 3. **Write it.** Call `update_sample_status` with `sampleId` (or `productId`),
@@ -46,9 +48,29 @@ what") is the `graylog-query` skill's job — see *Reading it back* below.
    Graylog event did **not** write — don't report unqualified success.
 
 > "Sold" is **not** a plain status here. `update_sample_status` rejects it on
-> purpose, because a sale must attribute revenue to a creator → use Workflow 2.
+> purpose, because a sale must attribute revenue to a creator → use Workflow 3.
 
-## Workflow 2 — Mark a sample SOLD (with creator attribution)
+## Workflow 2 — List a sample on a marketplace
+
+Records that a sample is up for resale — the step between "how much GMV did my
+content drive?" and "what did the listing sell for?". This is **analytics-only**:
+it emits a Graylog listing event and does **not** change the sample's status
+(a listing is intent-to-sell, not an inventory state).
+
+1. **Resolve the sample** via `list_samples` (prefer a specific `sampleId`).
+2. **Confirm the creator** (via `list_creators`) the listing is attributed to —
+   the same handle you'd attribute the eventual sale to.
+3. **Gather** `marketplace` + `askPrice` (plus optional `listingUrl`, `note`).
+4. **Write it.** Call `list_on_marketplace`; it emits `sample_listing_json`
+   (`creator` + `product_id` + `ask_price_num` + `marketplace`).
+5. **Report honestly.** Echo `message`; if `graylog` is `false`, the listing was
+   **not** recorded.
+
+> A listing does not mark the sample sold. When it actually sells, follow
+> Workflow 3 (`mark_sample_sold`). Comparing `ask_price_num` to the final
+> `gmv_num`/`net_num` is then a `graylog-query` question.
+
+## Workflow 3 — Mark a sample SOLD (with creator attribution)
 
 This is the revenue path. The creator-attribution prompt is mandatory.
 
@@ -101,6 +123,14 @@ python3 .../graylog_query.py --all -q 'product_id:"1729..."' \
 ```
 This stitches the sample's status changes and its sale alongside the scraper
 sources (videos/lives) that share the same `product_id` + `creator`.
+
+**What's listed for resale, and where:**
+```bash
+python3 .../graylog_query.py --all -q 'sample_listing_json:*' \
+  --fields creator,product_id,marketplace,ask_price_num --sort timestamp:desc
+```
+A `product_id` with a `sample_listing_json` but no later `sample_sold_json` is
+still on the market; `--terms marketplace` shows where listings cluster.
 
 Full field/query reference: [references/lifecycle-events.md](references/lifecycle-events.md).
 

--- a/.claude/skills/sample-lifecycle/references/lifecycle-events.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-events.md
@@ -1,6 +1,6 @@
 # Sample-lifecycle Graylog events
 
-The two events this skill writes, and how `graylog-query` reads them back. Both
+The events this skill writes, and how `graylog-query` reads them back. All
 are emitted by `core/lifecycle.ts` via `sendGelfMessage()` (defined in
 `core/graylog.ts`), which sends GELF `version:"1.1"`, `host:"thirsty-store-kiosk"`,
 single-`_`-prefixes every field, and drops empty/null values. Graylog strips the
@@ -51,6 +51,28 @@ Note: affiliate-export's `creator` is an *agency label*, but these resale events
 are authored by the skill, so the real `@handle` is stamped directly — resale
 revenue attributes more cleanly than affiliate data.
 
+## Event 3 — listing (marketplace)
+
+`short_message`: `thirsty sample listed: <name> @ $<askPrice> on <marketplace> → <creator>`
+
+Analytics-only — written by `recordSampleListing`; it does **not** touch Postgres
+(a listing is intent-to-sell, not an inventory status). It marks the step between
+the content-GMV question and the resale-net question.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sample_listing_json` | JSON string | `{productId, sampleId, name, creator, marketplace, askPrice, listingUrl?, listedAt, note?}` |
+| `creator` | string | attribution handle (same convention as Events 1–2) |
+| `ask_price_num` | number | the listing/ask price — compare to the eventual `gmv_num`/`net_num` |
+| `marketplace` | string | `ebay` / `offerup` / `fbmarketplace` / … |
+| `product_id` | string | join key |
+| `sample_id` | string | Postgres id (when a row matched) |
+| `sample_event` | string | `listed` (flat, filterable) |
+| `sample_source` | string | `skill-listing` |
+
+A `product_id` carrying a `sample_listing_json` with no later `sample_sold_json`
+is still on the market.
+
 ## Read-back recipes (`graylog-query`)
 
 `--terms` only counts; it can't SUM — fetch rows and sum the `*_num` field
@@ -77,6 +99,18 @@ python3 .../graylog_query.py --last 90d \
   --fields creator,product_id,marketplace,gmv_num,net_num --sort gmv_num:desc
 ```
 
+**What's currently listed for resale (and where):**
+```bash
+python3 .../graylog_query.py --all -q 'sample_listing_json:*' \
+  --fields creator,product_id,marketplace,ask_price_num --sort timestamp:desc
+```
+A `product_id` with a `sample_listing_json` and no later `sample_sold_json` is
+still on the market. `--terms marketplace` shows where listings cluster.
+
+**Ask vs. actual — did listings sell for what we asked?**
+Pull `sample_listing_json:*` (`ask_price_num`) and `sample_sold_json:*`
+(`gmv_num`) for the same `product_id` and compare per product.
+
 **Status history of one sample/product:**
 ```bash
 python3 .../graylog_query.py --all -q 'product_id:"1729..." AND sample_status_json:*' \
@@ -94,7 +128,8 @@ python3 .../graylog_query.py --all -q 'product_id:"1729..."' \
 
 `product_id` links: **intake** (`samples.qr_code`) → **status changes**
 (Event 1) → **content** (`source:tiktok-bookmarklet-product-analysis` etc.,
-which carry `Product ID` + `creator`) → **resale** (Event 2).
+which carry `Product ID` + `creator`) → **listing** (Event 3) → **resale**
+(Event 2).
 
 The weak link is **order-received** (`source:tiktok-bookmarklet-orders`): those
 scrape events carry neither `product_id` nor `creator` (product is matched by

--- a/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
@@ -1,0 +1,112 @@
+# Sample-product lifecycle — human steps + skill/MCP
+
+The full lifecycle of one sample-product, from barcode-photo intake to resale
+analytics. Each 🧑 human step is paired with the 🤖 skill/MCP action it triggers.
+Everything threads on one join key: `product_id` = the sample's `qr_code`, stamped
+alongside `sample_id` + `creator` on every Graylog event.
+
+**Status:** 🤖✅ built today · ⬜ stub / proposed · ⚠ gap (needs work).
+
+```mermaid
+flowchart TD
+    classDef human fill:#e3f2fd,stroke:#1565c0,color:#0d2a4a;
+    classDef skill fill:#e8f5e9,stroke:#2e7d32,color:#11331a;
+    classDef decision fill:#fff8e1,stroke:#f9a825,color:#3a2e00;
+    classDef data fill:#ede7f6,stroke:#5e35b1,color:#21103f;
+    classDef stub fill:#fff3e0,stroke:#ef6c00,color:#3a1f00,stroke-dasharray:5 4;
+    classDef gap fill:#ffebee,stroke:#c62828,color:#3a0000,stroke-dasharray:5 4;
+
+    subgraph INTAKE["1 · INTAKE — barcode/photo → catalog"]
+        H1["🧑 'Add this sample — here's a barcode photo'"]:::human
+        S1["🤖 /api/upc-lookup or /api/image-lookup<br/>SerpApi Lens/Shopping → ScrapeCreators match"]:::skill
+        D1{"Match correct?"}:::decision
+        H2["🧑 'No — find candidates for Cupid Desire Drops'"]:::human
+        S2["🤖 returns 5 candidate TikTok products to choose"]:::skill
+        D2{"Selects 1–5"}:::decision
+        S3["🤖 add to catalog: /api/sample-products upsert<br/>+ tracker sample row · productId = qr_code"]:::skill
+        D3{"productId unique?"}:::decision
+        S4["🤖 NEW unique sample-product lifecycle starts<br/>sample_id + qr_code (+ creator_id ⬜)"]:::skill
+        EX["🤖 attach as another physical unit<br/>of an existing product"]:::skill
+    end
+
+    H1 --> S1 --> D1
+    D1 -- yes --> S3
+    D1 -- no --> H2 --> S2 --> D2 --> S3
+    S3 --> D3
+    D3 -- unique --> S4
+    D3 -- exists --> EX
+
+    subgraph CONTENT["2 · CONTENT — multi-key attribution"]
+        H3["🧑 makes videos + LIVEs for the product"]:::human
+        S5["🤖 extension scrapers → Graylog<br/>product-analysis / streamer / live<br/>(creator + Product ID)"]:::skill
+        H4["🧑 scrapes their order list (extension)"]:::human
+        S6["🤖 order-received → Graylog<br/>⚠ no productId/creator yet — GAP"]:::gap
+    end
+
+    S4 --> H3 --> S5
+    S4 --> H4 --> S6
+
+    ATTR(["🧷 ONE sample-product lifecycle<br/>joined on productId = qr_code<br/>+ sample_id + creator"]):::data
+    S4 --> ATTR
+    S5 --> ATTR
+    S6 -. needs productId .-> ATTR
+
+    subgraph LIST["3 · LIST ON MARKETPLACE — ✅ built"]
+        H5["🧑 'List this on eBay / OfferUp / FB Marketplace for $45'"]:::human
+        S7["🤖 list_on_marketplace ✅<br/>Graylog sample_listing_json<br/>creator + product_id + ask_price_num"]:::skill
+    end
+
+    ATTR --> H5 --> S7
+
+    subgraph SOLD["4 · SOLD — ✅ built"]
+        H6["🧑 'Mark it sold on eBay for $40 → @wizardofdealz'"]:::human
+        S8["🤖 mark_sample_sold ✅<br/>Postgres status=sold · Graylog sample_sold_json<br/>creator + gmv_num + net_num"]:::skill
+        H7["🧑 'Sold a bulk lot of 12 samples for $300'"]:::human
+        S9["🤖 bulk_sample_sold ⬜ STUB<br/>allocate revenue across sample_ids/creators"]:::stub
+    end
+
+    S7 --> H6 --> S8
+    S7 --> H7 --> S9
+    S8 --> ATTR
+    S9 --> ATTR
+
+    subgraph ASK["5 · ANALYTICS — graylog-query reads it back"]
+        Q1["🧑 'How much GMV did my content drive?'<br/>(answerable after CONTENT)"]:::human
+        A1["🤖 graylog-query: affiliate gmv_num by creator"]:::skill
+        Q2["🧑 'What's listed, and what net profit did it sell for?'<br/>(answerable after LIST/SOLD)"]:::human
+        A2["🤖 graylog-query: ask_price_num (listing) vs<br/>net_num (sold), by creator"]:::skill
+        Q3["🧑 'Where do we make the most $ per sample product?'"]:::human
+        A3["🤖 graylog-query: net_num by marketplace / product_id"]:::skill
+        Q4["🧑 'Same questions for bulk sales?'"]:::human
+        A4["🤖 needs bulk_sold_json ⬜"]:::stub
+    end
+
+    ATTR --> ASK
+    Q1 --> A1
+    Q2 --> A2
+    Q3 --> A3
+    Q4 --> A4
+
+    subgraph LEGEND["legend"]
+        L1["🤖 ✅ built today"]:::skill
+        L2["⬜ stub / proposed"]:::stub
+        L3["⚠ gap — needs work"]:::gap
+        L4["🧷 join hub"]:::data
+        L5["🧑 human step"]:::human
+    end
+```
+
+## What's built vs. remaining
+
+- **✅ Built:** intake lookup (`/api/upc-lookup`, `/api/image-lookup`,
+  `/api/sample-products`), `update_sample_status`, `list_on_marketplace`,
+  `mark_sample_sold`, and `graylog-query` read-back.
+- **⬜ Stubs / proposed next:** `bulk_sample_sold` (one sale across N sample_ids →
+  per-sample `sample_sold_json` so existing per-creator/per-marketplace revenue
+  queries work on bulk too), and a stored `creator_id` on the sample at intake.
+- **⚠ Gap:** the order-received scrape carries no `productId`/`creator`, so the
+  order node can't auto-join (the dotted edge) until the scraper captures a
+  productId — out of scope for this skill.
+
+See [lifecycle-events.md](lifecycle-events.md) for the exact event field schemas
+and the `graylog-query` read-back recipes.

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -96,6 +96,28 @@ export type SoldResult = {
   message: string;
 };
 
+export type ListingInput = SampleRef & {
+  creator?: string;
+  marketplace?: string;
+  askPrice?: number | string;
+  listingUrl?: string;
+  note?: string;
+  operator?: string;
+};
+
+export type ListingResult = {
+  ok: boolean;
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  creator: string;
+  marketplace: string;
+  askPrice: number;
+  listingUrl: string | null;
+  graylog: boolean;
+  message: string;
+};
+
 const STATUSES = sampleStatuses as SampleStatusEntry[];
 
 // The full synced status vocabulary (statuses + badges) — served verbatim so the
@@ -422,6 +444,87 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
       marketplace,
       warnings,
     }),
+  };
+}
+
+// Record that a sample has been LISTED for resale on a marketplace — the step
+// between "how much GMV did my content drive?" and "what did the listing sell
+// for?". Analytics-only on purpose: a listing is intent-to-sell, not an
+// inventory-status change (there is no "listed" status), so this emits a Graylog
+// event and does NOT mutate Postgres. The event reuses the lifecycle vocabulary
+// (creator + product_id + sample_id) plus ask_price_num, so graylog-query can
+// answer "what's listed where" and compare ask price to the eventual sale.
+export async function recordSampleListing(
+  input: ListingInput,
+): Promise<ListingResult> {
+  const creator = String(input.creator || "").trim();
+  if (!creator) {
+    throw new Error(
+      "creator is required — which creator account is this listing attributed to?",
+    );
+  }
+  const marketplace = String(input.marketplace || "").trim();
+  if (!marketplace) {
+    throw new Error(
+      "marketplace is required (e.g. ebay, offerup, fbmarketplace)",
+    );
+  }
+  const askPrice = toNumber(input.askPrice);
+  if (!(askPrice > 0)) {
+    throw new Error("askPrice must be a positive number");
+  }
+
+  const row = await resolveSampleRow(input, { preferUnsold: true });
+  const sampleId = row ? Number(row.id) : null;
+  const productId = productIdOf(row, input);
+  const name = row ? String(row.name ?? "").trim() || null : null;
+  const listingUrl = String(input.listingUrl || "").trim() || null;
+  const note = String(input.note || "").trim();
+  const now = new Date().toISOString();
+
+  const graylog = await sendGelfMessage(
+    `thirsty sample listed: ${name ?? productId ?? "sample"} @ $${
+      askPrice.toFixed(2)
+    } on ${marketplace} → ${creator}`,
+    {
+      sample_listing_json: JSON.stringify({
+        productId,
+        sampleId,
+        name,
+        creator,
+        marketplace,
+        askPrice,
+        listingUrl: listingUrl || undefined,
+        listedAt: now,
+        note: note || undefined,
+      }),
+      creator,
+      ask_price_num: askPrice,
+      marketplace,
+      product_id: productId ?? undefined,
+      sample_id: sampleId != null ? String(sampleId) : undefined,
+      sample_event: "listed",
+      sample_source: "skill-listing",
+    },
+  );
+
+  const where = graylog ? "Graylog" : "nothing";
+  const warning = graylog
+    ? ""
+    : " WARNING: Graylog listing event was NOT written.";
+  return {
+    ok: graylog,
+    sampleId,
+    productId,
+    name,
+    creator,
+    marketplace,
+    askPrice,
+    listingUrl,
+    graylog,
+    message: `Listed ${name ?? productId ?? "sample"} at $${
+      askPrice.toFixed(2)
+    } on ${marketplace} for ${creator} (recorded to ${where}).${warning}`,
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -26,6 +26,7 @@ import {
 } from "./core/samples.ts";
 import {
   listSampleStatuses,
+  recordSampleListing,
   recordSampleSold,
   recordSampleStatus,
 } from "./core/lifecycle.ts";
@@ -1348,6 +1349,21 @@ export async function legacyHandler(req: Request): Promise<Response> {
         }
         try {
           return json(await recordSampleSold(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // List a sample on a resale marketplace — analytics-only Graylog event
+      // (the step between the content-GMV and resale-net questions). No Postgres
+      // status change: a listing is intent-to-sell, not an inventory state.
+      if (pathname === "/api/sample-listing") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordSampleListing(await readJsonBody(req)));
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return json({ ok: false, error: msg }, 400);

--- a/mcp/thirsty-samples/server.ts
+++ b/mcp/thirsty-samples/server.ts
@@ -217,6 +217,44 @@ const TOOLS = [
       additionalProperties: false,
     },
   },
+  {
+    name: "list_on_marketplace",
+    description:
+      "Record that a sample has been LISTED for resale on a marketplace " +
+      "(eBay/OfferUp/FB Marketplace) — the step between 'how much GMV did my " +
+      "content drive' and 'what did it sell for'. Analytics-only: emits a " +
+      "Graylog listing event (creator + product_id + ask_price_num); it does " +
+      "NOT change the sample's status or mark it sold. Identify the sample by " +
+      "sampleId (preferred) or productId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sampleId: { type: ["string", "number"], description: "Sample's Postgres id." },
+        productId: {
+          type: "string",
+          description: "TikTok productId / qr_code (used if sampleId omitted).",
+        },
+        creator: {
+          type: "string",
+          description:
+            "Creator @handle the listing is attributed to (validate against " +
+            "list_creators).",
+        },
+        marketplace: {
+          type: "string",
+          description: "Where it's listed: ebay, offerup, fbmarketplace, etc.",
+        },
+        askPrice: {
+          type: ["number", "string"],
+          description: "Listing/ask price (recorded as ask_price_num).",
+        },
+        listingUrl: { type: "string", description: "Optional URL of the live listing." },
+        note: { type: "string", description: "Optional note." },
+      },
+      required: ["creator", "marketplace", "askPrice"],
+      additionalProperties: false,
+    },
+  },
 ];
 
 const server = new Server(
@@ -294,6 +332,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             orderRef: args.orderRef,
             note: args.note,
             force: args.force,
+          },
+        });
+        break;
+      }
+
+      case "list_on_marketplace": {
+        result = await api("/api/sample-listing", {
+          method: "POST",
+          body: {
+            sampleId: args.sampleId,
+            productId: args.productId,
+            creator: args.creator,
+            marketplace: args.marketplace,
+            askPrice: args.askPrice,
+            listingUrl: args.listingUrl,
+            note: args.note,
           },
         });
         break;


### PR DESCRIPTION
## What

Adds the **`list_on_marketplace`** step to the sample-lifecycle skill/MCP — the stage between *"how much GMV did my content drive?"* and *"what did the listing sell for?"* — plus a Mermaid **lifecycle flow diagram** in the skill docs. Follow-up to #74.

## Listing event (`recordSampleListing`)

- **Analytics-only by design:** a listing is intent-to-sell, not an inventory-status change (there's no `listed` status), so it emits a Graylog event and does **not** mutate Postgres.
- Emits `sample_listing_json` plus flat fields reusing the lifecycle vocabulary: `creator` + `product_id` + `sample_id` + **`ask_price_num`** + `marketplace` (`sample_event:"listed"`, `sample_source:"skill-listing"`).
- So `graylog-query` can already answer *"what's listed where"* and compare `ask_price_num` (listing) to the eventual `gmv_num`/`net_num` (sale) — no changes to that skill.

### Changes
- `core/lifecycle.ts` — `recordSampleListing` (requires `creator`, `marketplace`, `askPrice>0`; optional `sampleId`/`productId`/`listingUrl`/`note`).
- `main.ts` — `POST /api/sample-listing` (open, clean-400 validation, matching the sibling routes).
- `mcp/thirsty-samples/server.ts` — `list_on_marketplace` tool (now 6 tools).
- `.claude/skills/sample-lifecycle/` — Workflow 2 (list) + renumbered SOLD to Workflow 3; `references/lifecycle-events.md` Event 3 + listing read-back recipes; new `references/lifecycle-flow.md` (the human-steps-vs-skill Mermaid chart, with built/stub/gap markers).

## Verification
- `deno check` clean on `core/lifecycle.ts`, `main.ts`, and the MCP server.
- MCP `tools/list` returns 6 tools including `list_on_marketplace`.
- Live validation: `/api/sample-listing` returns clean 400s for missing `creator` and non-positive `askPrice`.

## Still stub / gap (depicted in the diagram)
- `bulk_sample_sold` (one sale across N sample_ids → per-sample `sample_sold_json`).
- `creator_id` stored on the sample at intake.
- order-received scrape carries no `productId`/`creator` (the auto-join gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
