### PR TITLE
Add bulk_sample_sold — one sale across N samples, attributed per-creator

### DIFF
--- a/.claude/skills/sample-lifecycle/SKILL.md
+++ b/.claude/skills/sample-lifecycle/SKILL.md
@@ -7,13 +7,14 @@ description: >-
   state, list it for resale, or log a sale — e.g. "mark <product> as sold", "this
   sold on eBay for $40", "set <product> to cleared to sell", "reserve sample 42",
   "discontinue this one", "list this on eBay for $45", "I put it up on OfferUp",
-  "log a resale", "attribute this sale to @wizardofdealz". Each action writes a
+  "log a resale", "sold a bulk lot of 12 samples for $300", "attribute this sale
+  to @wizardofdealz". Each action writes a
   Graylog event (and, for status/sold, the inventory truth to Postgres), so a
   creator's listings and resale revenue are immediately queryable. For READ-ONLY
   questions about the data ("how much resale revenue did @x make", "what's listed
   where", "which samples sold this month", "what's in Graylog") use the
   graylog-query skill instead — this skill only WRITES.
-allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__list_on_marketplace, mcp__thirsty-samples__mark_sample_sold
+allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__list_on_marketplace, mcp__thirsty-samples__mark_sample_sold, mcp__thirsty-samples__bulk_sample_sold
 ---
 
 # sample-lifecycle
@@ -99,6 +100,26 @@ This is the revenue path. The creator-attribution prompt is mandatory.
 > would double-count the creator's revenue (Graylog events are append-only). If
 > the user genuinely needs to re-attribute, confirm first, then pass
 > `force: true` to `mark_sample_sold`.
+
+## Workflow 4 — Mark a bulk lot sold
+
+One marketplace sale across several samples (a lot), attributed per-creator.
+
+1. **Resolve the units** via `list_samples` — collect a `sampleId` per item
+   (preferred over productId so each physical unit is unambiguous).
+2. **Confirm the creator(s).** Each item can carry its own `creator`, or set a
+   lot-level `creator` as the default. Confirm handles via `list_creators`.
+3. **Gather** the lot `totalPrice` + `marketplace` (plus optional lot-level
+   `fees`/`shipping`/`costBasis`, allocated across items by gross share). Give an
+   item an explicit `price` to pin its share; otherwise the remaining total is
+   split equally.
+4. **Write it.** Call `bulk_sample_sold` with `items`, `totalPrice`,
+   `marketplace`. It emits one `sample_sold_json` per sample tagged with a shared
+   `bulk_id`, so every per-creator/per-marketplace revenue query already counts
+   the lot.
+5. **Report honestly.** Echo `message` (it reports `soldCount/itemCount`, the lot
+   `bulkId`, and net) and surface any per-item `failures` (e.g. a unit that was
+   already sold).
 
 ## Reading it back — composing with `graylog-query`
 

--- a/.claude/skills/sample-lifecycle/references/lifecycle-events.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-events.md
@@ -51,6 +51,13 @@ Note: affiliate-export's `creator` is an *agency label*, but these resale events
 are authored by the skill, so the real `@handle` is stamped directly — resale
 revenue attributes more cleanly than affiliate data.
 
+**Bulk lots.** A bulk sale (`recordBulkSampleSold`) emits one Event-2 record
+**per sample**, each with its own allocated `gmv_num`/`net_num` and `creator`,
+plus two fields tying it to the lot: **`bulk_id`** (shared across the lot) and
+**`bulk_total_num`** (the lot's gross); `sample_source` becomes
+`skill-bulk-resale`. Because each item is a normal `sample_sold_json`, every
+recipe below already counts bulk lots — query `bulk_id:"<id>"` to isolate one.
+
 ## Event 3 — listing (marketplace)
 
 `short_message`: `thirsty sample listed: <name> @ $<askPrice> on <marketplace> → <creator>`
@@ -82,6 +89,12 @@ client-side. Match handles with both forms: `(creator:"@x" OR creator.keyword:"@
 ```bash
 python3 .../graylog_query.py --all -q 'sample_sold_json:*' \
   --fields creator,product_id,marketplace,gmv_num,net_num --sort timestamp:desc
+```
+
+**One bulk lot's per-sample breakdown:**
+```bash
+python3 .../graylog_query.py --all -q 'bulk_id:"bulk-..."' \
+  --fields creator,product_id,sample_id,gmv_num,net_num,bulk_total_num
 ```
 
 **One creator's resale revenue, by marketplace:**

--- a/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
@@ -62,7 +62,7 @@ flowchart TD
         H6["🧑 'Mark it sold on eBay for $40 → @wizardofdealz'"]:::human
         S8["🤖 mark_sample_sold ✅<br/>Postgres status=sold · Graylog sample_sold_json<br/>creator + gmv_num + net_num"]:::skill
         H7["🧑 'Sold a bulk lot of 12 samples for $300'"]:::human
-        S9["🤖 bulk_sample_sold ⬜ STUB<br/>allocate revenue across sample_ids/creators"]:::stub
+        S9["🤖 bulk_sample_sold ✅<br/>allocate the lot across sample_ids/creators<br/>→ per-sample sample_sold_json + bulk_id"]:::skill
     end
 
     S7 --> H6 --> S8
@@ -78,7 +78,7 @@ flowchart TD
         Q3["🧑 'Where do we make the most $ per sample product?'"]:::human
         A3["🤖 graylog-query: net_num by marketplace / product_id"]:::skill
         Q4["🧑 'Same questions for bulk sales?'"]:::human
-        A4["🤖 needs bulk_sold_json ⬜"]:::stub
+        A4["🤖 graylog-query: bulk lots are normal<br/>sample_sold_json (bulk_id) — same recipes"]:::skill
     end
 
     ATTR --> ASK
@@ -100,10 +100,11 @@ flowchart TD
 
 - **✅ Built:** intake lookup (`/api/upc-lookup`, `/api/image-lookup`,
   `/api/sample-products`), `update_sample_status`, `list_on_marketplace`,
-  `mark_sample_sold`, and `graylog-query` read-back.
-- **⬜ Stubs / proposed next:** `bulk_sample_sold` (one sale across N sample_ids →
-  per-sample `sample_sold_json` so existing per-creator/per-marketplace revenue
-  queries work on bulk too), and a stored `creator_id` on the sample at intake.
+  `mark_sample_sold`, `bulk_sample_sold` (one sale across N sample_ids → per-sample
+  `sample_sold_json` + shared `bulk_id`, so existing revenue queries include bulk
+  lots), and `graylog-query` read-back.
+- **⬜ Proposed next:** a stored `creator_id` on the sample at intake (so content
+  attribution doesn't rely on matching scraper `creator` + `product_id`).
 - **⚠ Gap:** the order-received scrape carries no `productId`/`creator`, so the
   order node can't auto-join (the dotted edge) until the scraper captures a
   productId — out of scope for this skill.

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -77,6 +77,9 @@ export type SoldInput = SampleRef & {
   // Re-sell an already-sold sample on purpose (re-attribution). Off by default
   // because the Graylog revenue total can't be un-inflated — see the guard.
   force?: boolean;
+  // Set by recordBulkSampleSold to tie a per-sample sale back to its bulk lot.
+  bulkId?: string;
+  bulkTotal?: number | string;
 };
 
 export type SoldResult = {
@@ -93,6 +96,42 @@ export type SoldResult = {
   net: number;
   postgres: { updated: boolean; transactionId: number | null; reason?: string };
   graylog: boolean;
+  message: string;
+};
+
+export type BulkSoldItemInput = SampleRef & {
+  creator?: string;
+  price?: number | string;
+  note?: string;
+};
+
+export type BulkSoldInput = {
+  items?: BulkSoldItemInput[];
+  totalPrice?: number | string;
+  marketplace?: string;
+  creator?: string;
+  fees?: number | string;
+  shipping?: number | string;
+  costBasis?: number | string;
+  buyer?: string;
+  orderRef?: string;
+  note?: string;
+  force?: boolean;
+  bulkId?: string;
+  operator?: string;
+};
+
+export type BulkSoldResult = {
+  ok: boolean;
+  bulkId: string;
+  marketplace: string;
+  totalPrice: number;
+  allocatedTotal: number;
+  itemCount: number;
+  soldCount: number;
+  netTotal: number;
+  items: SoldResult[];
+  failures: { item: number; ref: string; error: string }[];
   message: string;
 };
 
@@ -372,6 +411,11 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
     reasons.push("no matching sample row in Postgres (Graylog event still written)");
   }
 
+  // Bulk-lot provenance (only present when called from recordBulkSampleSold).
+  const bulkId = String(input.bulkId || "").trim();
+  const bulkTotalNum = toNumber(input.bulkTotal);
+  const bulkTotal = Number.isFinite(bulkTotalNum) ? bulkTotalNum : null;
+
   const graylog = await sendGelfMessage(
     `thirsty sample sold: ${name ?? productId ?? "sample"} $${
       salePrice.toFixed(2)
@@ -392,6 +436,8 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
         orderRef: orderRef || undefined,
         soldAt: now,
         note: note || undefined,
+        bulkId: bulkId || undefined,
+        bulkTotal: bulkTotal ?? undefined,
       }),
       creator,
       gmv_num: salePrice,
@@ -404,7 +450,9 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
       product_id: productId ?? undefined,
       sample_id: sampleId != null ? String(sampleId) : undefined,
       sample_status: "sold",
-      sample_source: "skill-resale",
+      sample_source: bulkId ? "skill-bulk-resale" : "skill-resale",
+      bulk_id: bulkId || undefined,
+      bulk_total_num: bulkTotal ?? undefined,
     },
   );
 
@@ -444,6 +492,158 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
       marketplace,
       warnings,
     }),
+  };
+}
+
+// Mark a BULK lot sold: one marketplace sale spread across N samples, each
+// attributed to a (possibly different) creator. Allocates the lot total across
+// items (explicit per-item `price`, else an equal split of the remainder) and
+// allocates lot-level fees/shipping/costBasis proportionally to each item's
+// gross, then writes ONE per-sample sale via recordSampleSold stamped with a
+// shared bulk_id. Because each item still emits a normal sample_sold_json, every
+// existing per-creator / per-marketplace revenue query includes bulk lots with
+// no new read logic. Per-item failures (e.g. already-sold) are collected, not
+// fatal, so one bad unit doesn't strand the rest of the lot.
+export async function recordBulkSampleSold(
+  input: BulkSoldInput,
+): Promise<BulkSoldResult> {
+  const items = Array.isArray(input.items) ? input.items : [];
+  if (!items.length) {
+    throw new Error("items is required — the samples in the bulk lot");
+  }
+  const marketplace = String(input.marketplace || "").trim();
+  if (!marketplace) {
+    throw new Error(
+      "marketplace is required (e.g. ebay, offerup, fbmarketplace)",
+    );
+  }
+  const totalPrice = toNumber(input.totalPrice);
+  if (!(totalPrice > 0)) {
+    throw new Error("totalPrice must be a positive number");
+  }
+  const lotCreator = String(input.creator || "").trim();
+
+  // Validate creator + explicit price for every item up front, so a bad input
+  // never writes a partial lot.
+  const prepared = items.map((it, i) => {
+    const creator = String(it.creator || lotCreator || "").trim();
+    if (!creator) {
+      throw new Error(
+        `item ${i + 1}: creator is required (set item.creator or a lot-level creator)`,
+      );
+    }
+    let explicit: number | null = null;
+    if (it.price !== undefined) {
+      const p = toNumber(it.price);
+      if (!Number.isFinite(p) || p < 0) {
+        throw new Error(`item ${i + 1}: price must be a non-negative number`);
+      }
+      explicit = p;
+    }
+    return { it, creator, explicit };
+  });
+
+  // Allocate gross: honor explicit prices, split the remainder equally across
+  // the rest (last unpriced item absorbs the rounding remainder).
+  const explicitSum = round2(
+    prepared.reduce((sum, p) => sum + (p.explicit ?? 0), 0),
+  );
+  const remaining = round2(totalPrice - explicitSum);
+  const unpricedCount = prepared.filter((p) => p.explicit === null).length;
+  if (remaining < -0.001) {
+    throw new Error(
+      `explicit item prices ($${explicitSum.toFixed(2)}) exceed totalPrice ($${
+        totalPrice.toFixed(2)
+      })`,
+    );
+  }
+  if (unpricedCount === 0 && Math.abs(remaining) > 0.01) {
+    throw new Error(
+      `explicit item prices ($${explicitSum.toFixed(2)}) do not sum to totalPrice ($${
+        totalPrice.toFixed(2)
+      })`,
+    );
+  }
+  const per = unpricedCount
+    ? Math.floor((remaining / unpricedCount) * 100) / 100
+    : 0;
+  let unpricedSeen = 0;
+  const grosses = prepared.map((p) => {
+    if (p.explicit !== null) return p.explicit;
+    unpricedSeen++;
+    return unpricedSeen === unpricedCount
+      ? round2(remaining - per * (unpricedCount - 1))
+      : per;
+  });
+  if (grosses.some((g) => !(g > 0))) {
+    throw new Error(
+      "allocation produced a non-positive per-item price — give explicit item " +
+        "prices or a larger totalPrice",
+    );
+  }
+
+  const allocatedTotal = round2(grosses.reduce((sum, g) => sum + g, 0));
+  const fees = numOrZero(input.fees);
+  const shipping = numOrZero(input.shipping);
+  const costBasis = numOrZero(input.costBasis);
+  const bulkId = String(input.bulkId || "").trim() || `bulk-${crypto.randomUUID()}`;
+
+  const results: SoldResult[] = [];
+  const failures: { item: number; ref: string; error: string }[] = [];
+  for (let i = 0; i < prepared.length; i++) {
+    const { it, creator } = prepared[i];
+    const gross = grosses[i];
+    const share = allocatedTotal > 0 ? gross / allocatedTotal : 0;
+    try {
+      const result = await recordSampleSold({
+        sampleId: it.sampleId,
+        productId: it.productId,
+        qrCode: it.qrCode,
+        creator,
+        salePrice: gross,
+        marketplace,
+        fees: round2(fees * share),
+        shipping: round2(shipping * share),
+        costBasis: round2(costBasis * share),
+        buyer: input.buyer,
+        orderRef: input.orderRef,
+        note: [input.note, it.note].map((n) => String(n || "").trim())
+          .filter(Boolean).join(" | ") || undefined,
+        force: input.force,
+        operator: input.operator,
+        bulkId,
+        bulkTotal: totalPrice,
+      });
+      results.push(result);
+    } catch (error) {
+      failures.push({
+        item: i + 1,
+        ref: String(it.sampleId ?? it.productId ?? it.qrCode ?? i + 1),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const netTotal = round2(results.reduce((sum, r) => sum + r.net, 0));
+  const tail = failures.length
+    ? ` WARNING: ${failures.length} item(s) failed: ${
+      failures.map((f) => `#${f.item} (${f.ref}): ${f.error}`).join("; ")
+    }.`
+    : "";
+  return {
+    ok: failures.length === 0 && results.length > 0,
+    bulkId,
+    marketplace,
+    totalPrice,
+    allocatedTotal,
+    itemCount: items.length,
+    soldCount: results.length,
+    netTotal,
+    items: results,
+    failures,
+    message: `Bulk-sold ${results.length}/${items.length} sample(s) for $${
+      totalPrice.toFixed(2)
+    } via ${marketplace} (net $${netTotal.toFixed(2)}, lot ${bulkId}).${tail}`,
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -26,6 +26,7 @@ import {
 } from "./core/samples.ts";
 import {
   listSampleStatuses,
+  recordBulkSampleSold,
   recordSampleListing,
   recordSampleSold,
   recordSampleStatus,
@@ -1364,6 +1365,21 @@ export async function legacyHandler(req: Request): Promise<Response> {
         }
         try {
           return json(await recordSampleListing(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // Mark a BULK lot sold: one sale across N samples, attributed per-creator.
+      // Allocates the total + emits one sample_sold_json per sample (tagged with
+      // a shared bulk_id), so existing revenue queries include bulk lots.
+      if (pathname === "/api/sample-bulk-sold") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordBulkSampleSold(await readJsonBody(req)));
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return json({ ok: false, error: msg }, 400);

--- a/mcp/thirsty-samples/server.ts
+++ b/mcp/thirsty-samples/server.ts
@@ -255,6 +255,60 @@ const TOOLS = [
       additionalProperties: false,
     },
   },
+  {
+    name: "bulk_sample_sold",
+    description:
+      "Mark a BULK lot sold — one marketplace sale spread across several " +
+      "samples, each attributed to a creator. Allocates the lot total across " +
+      "items (explicit per-item price, else an equal split) and emits one " +
+      "sample_sold_json per sample tagged with a shared bulk_id, so the normal " +
+      "per-creator / per-marketplace revenue queries include bulk lots. Prefer " +
+      "explicit sampleIds. ALWAYS confirm the per-item (or lot) creator(s) first.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          description:
+            "The samples in the lot. Each: sampleId (preferred) or productId, " +
+            "an optional creator (falls back to the lot-level creator), an " +
+            "optional explicit price (else the remaining total is split equally).",
+          items: {
+            type: "object",
+            properties: {
+              sampleId: { type: ["string", "number"] },
+              productId: { type: "string" },
+              creator: { type: "string" },
+              price: { type: ["number", "string"] },
+              note: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        totalPrice: {
+          type: ["number", "string"],
+          description: "Gross total the whole lot sold for.",
+        },
+        marketplace: { type: "string", description: "ebay, offerup, fbmarketplace, etc." },
+        creator: {
+          type: "string",
+          description: "Lot-level default creator for items that don't set their own.",
+        },
+        fees: { type: ["number", "string"], description: "Lot fees (allocated by gross share)." },
+        shipping: { type: ["number", "string"], description: "Lot shipping (allocated)." },
+        costBasis: { type: ["number", "string"], description: "Lot cost basis (allocated)." },
+        buyer: { type: "string", description: "Optional buyer." },
+        orderRef: { type: "string", description: "Optional marketplace order/lot ref." },
+        note: { type: "string", description: "Optional lot-level note." },
+        force: {
+          type: "boolean",
+          description: "Re-attribute already-sold units in the lot (default false).",
+        },
+      },
+      required: ["items", "totalPrice", "marketplace"],
+      additionalProperties: false,
+    },
+  },
 ];
 
 const server = new Server(
@@ -348,6 +402,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             askPrice: args.askPrice,
             listingUrl: args.listingUrl,
             note: args.note,
+          },
+        });
+        break;
+      }
+
+      case "bulk_sample_sold": {
+        result = await api("/api/sample-bulk-sold", {
+          method: "POST",
+          body: {
+            items: args.items,
+            totalPrice: args.totalPrice,
+            marketplace: args.marketplace,
+            creator: args.creator,
+            fees: args.fees,
+            shipping: args.shipping,
+            costBasis: args.costBasis,
+            buyer: args.buyer,
+            orderRef: args.orderRef,
+            note: args.note,
+            force: args.force,
           },
         });
         break;


### PR DESCRIPTION
## What

Adds **`bulk_sample_sold`** — one marketplace sale spread across N samples, each attributed to a (possibly different) creator. Follow-up to #74/#75.

## How

- `recordBulkSampleSold` allocates the lot `totalPrice` across items (explicit per-item `price`, else an equal split of the remainder; last unpriced item absorbs rounding), and allocates lot-level `fees`/`shipping`/`costBasis` proportionally to each item's gross share.
- It then writes **one per-sample sale via `recordSampleSold`**, stamped with a shared **`bulk_id`** + **`bulk_total_num`** (`sample_source: skill-bulk-resale`). Because each item is a normal `sample_sold_json`, **every existing per-creator / per-marketplace revenue query already includes bulk lots** — no new read logic. Query `bulk_id:"<id>"` to isolate one lot.
- Per-item failures (e.g. an already-sold unit) are collected into `failures`, not fatal — one bad unit doesn't strand the rest of the lot. Up-front validation (creator, allocation) prevents partial writes on bad input.

### Changes
- `core/lifecycle.ts` — `recordBulkSampleSold` (+ `bulkId`/`bulkTotal` stamped on the existing sold event).
- `main.ts` — `POST /api/sample-bulk-sold`.
- `mcp/thirsty-samples/server.ts` — `bulk_sample_sold` tool (now 7 tools).
- skill docs — Workflow 4 (bulk), bulk note + read-back recipe in `lifecycle-events.md`, `lifecycle-flow.md` marks bulk **built**.

## Verification
- `deno check` clean across `core/lifecycle.ts`, `main.ts`, MCP server.
- MCP `tools/list` returns 7 tools including `bulk_sample_sold`.
- Live validation: `/api/sample-bulk-sold` returns clean 400s for no-items, missing creator, explicit-prices-exceed-total, and non-positive allocation.

## Remaining (depicted in lifecycle-flow.md)
- `creator_id` stored on the sample at intake.
- order-received scrape carries no `productId`/`creator` (the auto-join gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
