### PR TITLE
Add creator assignment + agency-bucket fulfillment + derived dropdown

### DIFF
--- a/.claude/skills/sample-lifecycle/SKILL.md
+++ b/.claude/skills/sample-lifecycle/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: sample-lifecycle
 description: >-
-  Update a sample's status, or mark a sample SOLD and attribute the resale
-  revenue to a creator account, in the LP Sample Tracker (thirsty.store /
-  admin.thirsty.store). Trigger whenever the user wants to change a sample's
-  state, list it for resale, or log a sale — e.g. "mark <product> as sold", "this
-  sold on eBay for $40", "set <product> to cleared to sell", "reserve sample 42",
-  "discontinue this one", "list this on eBay for $45", "I put it up on OfferUp",
-  "log a resale", "sold a bulk lot of 12 samples for $300", "attribute this sale
-  to @wizardofdealz". Each action writes a
-  Graylog event (and, for status/sold, the inventory truth to Postgres), so a
-  creator's listings and resale revenue are immediately queryable. For READ-ONLY
-  questions about the data ("how much resale revenue did @x make", "what's listed
-  where", "which samples sold this month", "what's in Graylog") use the
-  graylog-query skill instead — this skill only WRITES.
-allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__list_on_marketplace, mcp__thirsty-samples__mark_sample_sold, mcp__thirsty-samples__bulk_sample_sold
+  Manage a sample's full lifecycle in the LP Sample Tracker (thirsty.store /
+  admin.thirsty.store): change status, ASSIGN a sample to a creator, intake an
+  agency bulk lot, list it for resale, or log a (bulk) sale. Trigger whenever the
+  user wants to act on a sample — e.g. "assign 1 Cupids Desire Drops to
+  @boosteddealsdaily", "check this out to @x", "we got 50 of <product> for the
+  agency / credit them to kyle", "mark <product> as sold", "this sold on eBay for
+  $40", "set <product> to cleared to sell", "reserve sample 42", "list this on
+  eBay for $45", "sold a bulk lot of 12 samples for $300", "attribute this sale to
+  @wizardofdealz". Each action writes a Graylog event (and, for
+  status/sold/assign, the inventory truth to Postgres). For READ-ONLY questions
+  ("how much resale revenue did @x make", "what's listed where", "which samples
+  sold this month", "who's assigned what") use the graylog-query skill instead —
+  this skill only WRITES.
+allowed-tools: mcp__thirsty-samples__list_samples, mcp__thirsty-samples__list_sample_statuses, mcp__thirsty-samples__list_creators, mcp__thirsty-samples__list_product_creators, mcp__thirsty-samples__update_sample_status, mcp__thirsty-samples__list_on_marketplace, mcp__thirsty-samples__mark_sample_sold, mcp__thirsty-samples__bulk_sample_sold, mcp__thirsty-samples__agency_intake, mcp__thirsty-samples__assign_sample
 ---
 
 # sample-lifecycle
@@ -120,6 +120,39 @@ One marketplace sale across several samples (a lot), attributed per-creator.
 5. **Report honestly.** Echo `message` (it reports `soldCount/itemCount`, the lot
    `bulkId`, and net) and surface any per-item `failures` (e.g. a unit that was
    already sold).
+
+## Workflow 5 — Agency bulk intake (credit a lot to a bucket)
+
+When a bulk sample order arrives for an agency (e.g. "we got 50 Cupids Desire
+Drops for kyle's agency"), credit them to an agency bucket **before** any creator
+is assigned. The units sit in `reserved` (held), `checked_out_to = <bucket>`.
+
+1. **Gather** the `productId` (or name), the `agencyBucket` (e.g. `kyle`), and
+   `qty`.
+2. **Write it.** Call `agency_intake` (`productId` + `qty` + `agencyBucket`). It
+   creates that many `reserved` units and emits a `sample_intake_json` event.
+   (To credit units that already exist, pass `sampleIds` instead of `qty`.)
+3. **Report.** Echo `message` (how many credited to which bucket) + the
+   `sampleIds`.
+
+## Workflow 6 — Assign / fulfill a sample to a creator
+
+"Assign 1 Cupids Desire Drops to @boosteddealsdaily." Moves one unit out of the
+agency bucket to that creator and **checks it out**.
+
+1. **Resolve the unit** via `list_samples` (prefer a specific `sampleId`; a
+   `reserved` bucket unit is pulled first when you pass a `productId`).
+2. **Confirm the creator.** Call `list_product_creators` for that product — the
+   derived candidate list (creators who ordered it; pass `includeAllKnown` to
+   also offer others). Confirm the exact handle; don't guess.
+3. **Write it.** Call `assign_sample` (`sampleId`/`productId` + `creator`). It
+   sets the sample to `checked_out` (`checked_out_to = creator`), auto-matches a
+   campaign, records a `check_out` transaction, and emits `sample_assignment_json`.
+4. **Surface the note.** The result's `message` + `enrichment[]` carry the
+   nice-to-know lines: any **bundle** the sample belongs to (real), and — if the
+   product matches a configured campaign — the **daily-video goal** and **promo**
+   (both labelled `[from campaign-config]`, since no measured goal exists yet).
+   Relay these to the admin.
 
 ## Reading it back — composing with `graylog-query`
 

--- a/.claude/skills/sample-lifecycle/references/lifecycle-events.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-events.md
@@ -80,6 +80,45 @@ the content-GMV question and the resale-net question.
 A `product_id` carrying a `sample_listing_json` with no later `sample_sold_json`
 is still on the market.
 
+## Event 4 — agency intake (bulk lot → bucket)
+
+`short_message`: `thirsty agency intake: <name> ×<qty> → bucket <agency_bucket>`
+
+Written by `recordAgencyIntake`. Postgres: each unit set/created `reserved` with
+`checked_out_to = <agency_bucket>` + an `agency_intake` transaction.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sample_intake_json` | JSON string | `{productId, sampleIds, name, agencyBucket, qty, note?, intakeAt}` |
+| `sample_event` | string | `agency_intake` |
+| `agency_bucket` | string | the bucket/admin credited (e.g. `kyle`) |
+| `qty_num` | number | units in the lot |
+| `product_id` | string | join key |
+| `sample_source` | string | `skill-agency-intake` |
+
+## Event 5 — assignment (fulfillment → checked out)
+
+`short_message`: `thirsty sample assigned: <name> → <creator>`
+
+Written by `recordSampleAssignment`. Postgres: the exact check-out field-set
+(`status='checked_out'`, `checked_out_to=<creator>`, `checked_out_at`) + a
+`check_out` transaction whose `notes` carry the campaign + enrichment summary.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sample_assignment_json` | JSON string | `{productId, sampleId, name, creator, agencyBucket?, campaign?, campaignId?, fromStatus, assignedAt, note?}` |
+| `creator` | string | who it's assigned to (reuses the lifecycle creator vocabulary) |
+| `sample_status` | string | `checked_out` |
+| `sample_event` | string | `assigned` |
+| `agency_bucket` | string | the bucket it came from, if any |
+| `campaign` / `campaign_id` | string | matched campaign (config-driven — no campaign data source yet) |
+| `product_id` / `sample_id` | string | join keys |
+| `sample_source` | string | `skill-assignment` |
+
+The assignment response also returns an `enrichment[]` note: **bundle** membership
+(REAL, from `samples.bundle_id`) + the campaign's **daily-video goal** and
+**promo** (CONFIG from `core/campaign-config.json`, labelled `[from campaign-config]`).
+
 ## Read-back recipes (`graylog-query`)
 
 `--terms` only counts; it can't SUM — fetch rows and sum the `*_num` field
@@ -137,9 +176,22 @@ python3 .../graylog_query.py --all -q 'product_id:"1729..."' \
   --fields source,creator,sample_status,gmv_num,sample_status_json,sample_sold_json
 ```
 
+**Who's assigned what / agency-bucket holdings:**
+```bash
+# assignments (per creator)
+python3 .../graylog_query.py --all -q 'sample_event:assigned' \
+  --fields creator,product_id,sample_id,agency_bucket,campaign --sort timestamp:desc
+# agency intakes (per bucket)
+python3 .../graylog_query.py --all -q 'sample_event:agency_intake' \
+  --terms agency_bucket
+```
+(Current assignment is also the live Postgres truth: `GET /api/samples?status=checked_out`
+→ `checked_out_to` is the creator; `status=reserved` → `checked_out_to` is the bucket.)
+
 ## Lifecycle join — current reach and the gap
 
-`product_id` links: **intake** (`samples.qr_code`) → **status changes**
+`product_id` links: **intake** (`samples.qr_code`) → **agency bucket** (Event 4)
+→ **assignment / checkout to a creator** (Event 5) → **status changes**
 (Event 1) → **content** (`source:tiktok-bookmarklet-product-analysis` etc.,
 which carry `Product ID` + `creator`) → **listing** (Event 3) → **resale**
 (Event 2).

--- a/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-flow.md
@@ -25,7 +25,7 @@ flowchart TD
         D2{"Selects 1–5"}:::decision
         S3["🤖 add to catalog: /api/sample-products upsert<br/>+ tracker sample row · productId = qr_code"]:::skill
         D3{"productId unique?"}:::decision
-        S4["🤖 NEW unique sample-product lifecycle starts<br/>sample_id + qr_code (+ creator_id ⬜)"]:::skill
+        S4["🤖 NEW unique sample-product lifecycle starts<br/>sample_id + qr_code (creator set via assign_sample ✅)"]:::skill
         EX["🤖 attach as another physical unit<br/>of an existing product"]:::skill
     end
 
@@ -50,6 +50,19 @@ flowchart TD
     S4 --> ATTR
     S5 --> ATTR
     S6 -. needs productId .-> ATTR
+
+    subgraph ASSIGN["1b · ASSIGN — agency fulfillment + creator assignment — ✅ built"]
+        H8["🧑 'we got 50 Cupids Desire Drops for kyle's agency'"]:::human
+        S10["🤖 agency_intake ✅<br/>N units → reserved, credited to bucket (kyle)<br/>sample_intake_json"]:::skill
+        H9["🧑 'assign 1 Cupids Desire Drops to @boosteddealsdaily'"]:::human
+        S11["🤖 list_product_creators ✅ (derived dropdown:<br/>creators who ordered it — affiliate-export)"]:::skill
+        S12["🤖 assign_sample ✅ → checked_out + creator<br/>+ campaign match + enrichment note<br/>(bundle REAL · daily-goal/promo CONFIG)"]:::skill
+    end
+
+    S4 --> H8 --> S10 --> H9
+    H9 --> S11 --> S12
+    S12 --> ATTR
+    S12 -. assigned creator makes content .-> H3
 
     subgraph LIST["3 · LIST ON MARKETPLACE — ✅ built"]
         H5["🧑 'List this on eBay / OfferUp / FB Marketplace for $45'"]:::human
@@ -99,15 +112,21 @@ flowchart TD
 ## What's built vs. remaining
 
 - **✅ Built:** intake lookup (`/api/upc-lookup`, `/api/image-lookup`,
-  `/api/sample-products`), `update_sample_status`, `list_on_marketplace`,
-  `mark_sample_sold`, `bulk_sample_sold` (one sale across N sample_ids → per-sample
-  `sample_sold_json` + shared `bulk_id`, so existing revenue queries include bulk
-  lots), and `graylog-query` read-back.
-- **⬜ Proposed next:** a stored `creator_id` on the sample at intake (so content
-  attribution doesn't rely on matching scraper `creator` + `product_id`).
-- **⚠ Gap:** the order-received scrape carries no `productId`/`creator`, so the
-  order node can't auto-join (the dotted edge) until the scraper captures a
-  productId — out of scope for this skill.
+  `/api/sample-products`), `update_sample_status`, `list_product_creators`
+  (derived assigned-creator dropdown), `agency_intake` (bulk lot → reserved
+  bucket), `assign_sample` (fulfillment → `checked_out` + campaign match +
+  bundle/goal/promo enrichment note), `list_on_marketplace`, `mark_sample_sold`,
+  `bulk_sample_sold`, and `graylog-query` read-back. Creator attribution is set
+  via `assign_sample` (`checked_out_to`), so no `creator_id`-at-intake column is
+  needed.
+- **🟡 Config, not measured:** campaign membership + daily-video goal + promo come
+  from `core/campaign-config.json` (no campaign/goal/promo data source exists yet
+  — the enrichment note labels them `[from campaign-config]`). Bundle membership
+  in the note IS real (`samples.bundle_id`).
+- **⚠ Gap:** the order-received / order-list scrape carries no `productId`/`creator`,
+  so it can't itself feed the derived dropdown — creators-for-product are derived
+  from `tiktok-affiliate-export` instead. Closing the order-scrape gap needs a
+  tok-scrape change to stamp `_creator`/`_product_id` — out of scope here.
 
 See [lifecycle-events.md](lifecycle-events.md) for the exact event field schemas
 and the `graylog-query` read-back recipes.

--- a/core/campaign-config.json
+++ b/core/campaign-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "CONFIG, not measured data. Campaigns / video goals / promos have no Graylog or Postgres source today, so the assignment enrichment note reads goal+promo from here and labels them as configured. Match a campaign to a product by productIds (exact qr_code/productId) or productMatch (case-insensitive name substrings). Bundle membership in the note is REAL (from samples.bundle_id); only goal/promo come from this file.",
+  "defaultDailyVideoGoal": 3,
+  "campaigns": [
+    {
+      "id": "cupids-2026",
+      "name": "Cupids Desire",
+      "productMatch": ["cupid", "desire drops"],
+      "productIds": [],
+      "dailyVideoGoal": 5,
+      "endsAt": "2026-07-31",
+      "promo": "5 videos for $50 Cupids promo"
+    }
+  ]
+}

--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -272,6 +272,53 @@ export async function fetchKnownCreators(limit = 1000): Promise<string[]> {
   }
 }
 
+// Distinct creators who *ordered* a given product, for the assigned-creator
+// dropdown. The only Graylog source carrying both a top-level `product_id` and a
+// `creator` on one message is tiktok-affiliate-export, so that's the basis.
+// (Caveat: affiliate-export's `creator` is mirrored from the AGENCY label, not a
+// real @handle — callers should treat these as agency-derived. The order-list
+// scrape carries neither creator nor product_id, so it can't contribute — the
+// known order-received gap.) Mirrors fetchKnownCreators; product_id matched on
+// both analyzed + .keyword like the creator convention.
+export async function fetchCreatorsForProduct(
+  productId: string,
+  limit = 1000,
+): Promise<string[]> {
+  const config = graylogConfigFromEnv();
+  const pid = String(productId || "").trim();
+  if (!config || !pid) return [];
+
+  const escaped = pid.replace(/"/g, '\\"');
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 1000;
+
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365 * 5,
+    };
+    const messages = await searchGraylog(
+      wide,
+      `source:tiktok-affiliate-export AND (product_id:"${escaped}" OR product_id.keyword:"${escaped}")`,
+      Math.max(200, Math.min(safeLimit, 1000)),
+      ["timestamp", "creator", "product_id"],
+    );
+    const seen = new Set<string>();
+    for (const message of messages) {
+      const creator = typeof message.creator === "string"
+        ? message.creator.trim()
+        : "";
+      if (creator) seen.add(creator);
+    }
+    return [...seen].sort((a, b) => {
+      const aRank = a.startsWith("@") ? 0 : 1;
+      const bRank = b.startsWith("@") ? 0 : 1;
+      return aRank - bRank || a.localeCompare(b);
+    });
+  } catch {
+    return [];
+  }
+}
+
 export function graylogConfigFromEnv(): GraylogConfig | null {
   const url = normalizeGraylogUrl(
     envValue("GRAYLOG_API_URL") || envValue("GRAYLOG_URL"),

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -22,8 +22,9 @@
 // systems reconcile even when a qr_code holds a barcode instead of a real id.
 
 import { sendGelfMessage } from "./graylog.ts";
-import { InventoryTransactions, Samples } from "../db.ts";
+import { Bundles, InventoryTransactions, Samples } from "../db.ts";
 import sampleStatuses from "./sample-statuses.json" with { type: "json" };
+import campaignConfig from "./campaign-config.json" with { type: "json" };
 
 export type SampleStatusEntry = {
   value: string;
@@ -157,12 +158,181 @@ export type ListingResult = {
   message: string;
 };
 
+export type CampaignEntry = {
+  id: string;
+  name: string;
+  productMatch?: string[];
+  productIds?: string[];
+  dailyVideoGoal?: number;
+  endsAt?: string;
+  promo?: string;
+};
+
+export type AgencyIntakeInput = {
+  productId?: string;
+  qrCode?: string;
+  name?: string;
+  sampleIds?: Array<string | number>;
+  agencyBucket?: string;
+  qty?: number | string;
+  operator?: string;
+  note?: string;
+};
+
+export type AgencyIntakeResult = {
+  ok: boolean;
+  productId: string | null;
+  name: string | null;
+  agencyBucket: string;
+  qty: number;
+  sampleIds: number[];
+  postgres: { created: number; updated: number; reason?: string };
+  graylog: boolean;
+  message: string;
+};
+
+export type AssignmentInput = SampleRef & {
+  creator?: string;
+  agencyBucket?: string;
+  campaign?: string;
+  campaignId?: string;
+  operator?: string;
+  note?: string;
+};
+
+export type AssignmentResult = {
+  ok: boolean;
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  creator: string;
+  fromStatus: string | null;
+  agencyBucket: string | null;
+  campaign: string | null;
+  enrichment: string[];
+  postgres: { updated: boolean; transactionId: number | null; reason?: string };
+  graylog: boolean;
+  message: string;
+};
+
 const STATUSES = sampleStatuses as SampleStatusEntry[];
 
 // The full synced status vocabulary (statuses + badges) — served verbatim so the
 // MCP/skill validate against the same single source the tracker uses.
 export function listSampleStatuses(): SampleStatusEntry[] {
   return STATUSES;
+}
+
+const CAMPAIGNS = campaignConfig as {
+  defaultDailyVideoGoal?: number;
+  campaigns?: CampaignEntry[];
+};
+
+// Match a product to a configured campaign by exact productId or a case-
+// insensitive name substring. CONFIG-driven — there is no campaign data source
+// yet, so a match only tells the enrichment note which goal/promo text to show.
+function matchCampaign(
+  productId: string | null,
+  name: string | null,
+): CampaignEntry | null {
+  const pid = String(productId || "").trim();
+  const nm = String(name || "").toLowerCase();
+  for (const c of CAMPAIGNS.campaigns ?? []) {
+    if (pid && Array.isArray(c.productIds) && c.productIds.includes(pid)) return c;
+    if (
+      nm && Array.isArray(c.productMatch) &&
+      c.productMatch.some((t) => nm.includes(String(t).toLowerCase()))
+    ) return c;
+  }
+  return null;
+}
+
+function daysUntil(iso: string): number | null {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  return Math.floor((t - Date.now()) / 86_400_000);
+}
+
+// Best-effort audit transaction (the sample-row write is the source of truth).
+async function safeTxn(
+  sampleId: unknown,
+  recipient: string,
+  operator: string,
+  scannedCode: string,
+  notes: string,
+  action: string,
+): Promise<void> {
+  try {
+    await InventoryTransactions.create({
+      action,
+      sample_id: sampleId,
+      operator: operator || null,
+      checked_out_to: recipient || null,
+      scanned_code: scannedCode || null,
+      notes,
+    });
+  } catch {
+    // audit only — never block the status write on it
+  }
+}
+
+// "Nice-to-know" lines for an assignment. Bundle membership is REAL
+// (samples.bundle_id → bundles + siblings); the daily-video goal and promo are
+// CONFIG from campaign-config.json and are labelled `[from campaign-config]` so
+// nobody mistakes them for measured data. No goal/promo data is invented.
+async function buildEnrichment(
+  row: SampleRow | null,
+  campaign: CampaignEntry | null,
+): Promise<string[]> {
+  const lines: string[] = [];
+
+  const bundleId = row?.bundle_id;
+  if (bundleId !== undefined && bundleId !== null) {
+    try {
+      const bundles = await Bundles.filter(
+        { id: String(bundleId) },
+        undefined,
+        1,
+      ) as SampleRow[];
+      const bundle = bundles[0];
+      if (bundle) {
+        const siblings = await Samples.filter(
+          { bundle_id: String(bundleId) },
+          undefined,
+          50,
+        ) as SampleRow[];
+        const extra = siblings.length > 1 ? ` (${siblings.length} items)` : "";
+        lines.push(
+          `Heads up: this sample is part of the "${
+            String(bundle.name ?? "").trim() || "?"
+          }" bundle${extra}.`,
+        );
+      }
+    } catch {
+      // bundle enrichment is best-effort
+    }
+  }
+
+  if (campaign) {
+    const goal = campaign.dailyVideoGoal ?? CAMPAIGNS.defaultDailyVideoGoal ?? 3;
+    const left = campaign.endsAt ? daysUntil(campaign.endsAt) : null;
+    let goalLine = `Campaign "${campaign.name}": aim for ${goal} video${
+      goal === 1 ? "" : "s"
+    }/day to hit goal`;
+    if (left !== null && left >= 0) {
+      goalLine += ` — ends ${campaign.endsAt} (~${left} day${
+        left === 1 ? "" : "s"
+      } left)`;
+    }
+    lines.push(`${goalLine}. [goal from campaign-config]`);
+    if (campaign.promo) {
+      lines.push(
+        `Offer: want to join the ${campaign.promo}? [promo from campaign-config]`,
+      );
+    }
+  }
+
+  return lines;
 }
 
 // Only `kind:"status"` values can live in the single `samples.status` column;
@@ -180,7 +350,7 @@ function isStatusValue(value: string): boolean {
 // key for a sale we prefer a not-yet-sold row (newest first).
 async function resolveSampleRow(
   ref: SampleRef,
-  opts: { preferUnsold?: boolean } = {},
+  opts: { preferUnsold?: boolean; preferReserved?: boolean } = {},
 ): Promise<SampleRow | null> {
   const id = String(ref.sampleId ?? "").trim();
   if (id) {
@@ -196,9 +366,15 @@ async function resolveSampleRow(
       25,
     ) as SampleRow[];
     if (!rows.length) return null;
+    const statusOf = (r: SampleRow) => String(r.status ?? "").trim();
+    // Fulfillment pulls from the agency bucket first (a `reserved` unit), then
+    // any not-yet-sold unit, then whatever's newest.
+    if (opts.preferReserved) {
+      return rows.find((r) => statusOf(r) === "reserved") ??
+        rows.find((r) => statusOf(r) !== "sold") ?? rows[0];
+    }
     if (opts.preferUnsold) {
-      const unsold = rows.find((r) => String(r.status ?? "").trim() !== "sold");
-      return unsold ?? rows[0];
+      return rows.find((r) => statusOf(r) !== "sold") ?? rows[0];
     }
     return rows[0];
   }
@@ -725,6 +901,287 @@ export async function recordSampleListing(
     message: `Listed ${name ?? productId ?? "sample"} at $${
       askPrice.toFixed(2)
     } on ${marketplace} for ${creator} (recorded to ${where}).${warning}`,
+  };
+}
+
+// Agency intake — credit a bulk lot of one product to an agency bucket (e.g.
+// "kyle") BEFORE any creator is assigned. Units sit in `reserved` with
+// checked_out_to = the bucket. With `sampleIds`, credits existing rows; with
+// `productId` + `qty`, creates that many reserved rows (a fresh shipment). Emits
+// one lot-level Graylog `sample_intake_json` event.
+export async function recordAgencyIntake(
+  input: AgencyIntakeInput,
+): Promise<AgencyIntakeResult> {
+  const agencyBucket = String(input.agencyBucket || "").trim();
+  if (!agencyBucket) {
+    throw new Error(
+      "agencyBucket is required — which agency/admin bucket to credit (e.g. kyle)",
+    );
+  }
+  const explicitIds = Array.isArray(input.sampleIds)
+    ? input.sampleIds.map((x) => String(x).trim()).filter(Boolean)
+    : [];
+  const productId = String(input.productId ?? input.qrCode ?? "").trim();
+  if (!explicitIds.length && !productId) {
+    throw new Error("productId (or sampleIds) is required");
+  }
+
+  const now = new Date().toISOString();
+  const note = String(input.note || "").trim();
+  const operator = String(input.operator || "").trim();
+
+  // Name: explicit, else borrowed from an existing row for this productId.
+  let name = String(input.name || "").trim();
+  if (!name && productId) {
+    try {
+      const existing = await Samples.filter(
+        { qr_code: productId },
+        "-created_at",
+        1,
+      ) as SampleRow[];
+      name = existing[0] ? String(existing[0].name ?? "").trim() : "";
+    } catch {
+      // fall through to productId as the name
+    }
+  }
+  if (!name) name = productId || "sample";
+
+  const sampleIds: number[] = [];
+  let created = 0;
+  let updated = 0;
+  const reasons: string[] = [];
+
+  if (explicitIds.length) {
+    for (const id of explicitIds) {
+      try {
+        const r = await Samples.update(id, {
+          status: "reserved",
+          checked_out_to: agencyBucket,
+          checked_out_at: now,
+        }) as SampleRow | undefined;
+        if (r?.id != null) {
+          sampleIds.push(Number(r.id));
+          updated++;
+          await safeTxn(
+            r.id,
+            agencyBucket,
+            operator,
+            productId || String(r.qr_code ?? ""),
+            `agency intake: credited to ${agencyBucket}${note ? ` | ${note}` : ""}`,
+            "agency_intake",
+          );
+        }
+      } catch (error) {
+        reasons.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+  } else {
+    const qty = Math.max(1, Math.min(200, Math.trunc(numOrZero(input.qty) || 1)));
+    for (let i = 0; i < qty; i++) {
+      try {
+        const r = await Samples.create({
+          name,
+          qr_code: productId,
+          status: "reserved",
+          checked_out_to: agencyBucket,
+          checked_out_at: now,
+          notes: `agency intake → ${agencyBucket}${note ? ` | ${note}` : ""}`,
+        }) as SampleRow | undefined;
+        if (r?.id != null) {
+          sampleIds.push(Number(r.id));
+          created++;
+          await safeTxn(
+            r.id,
+            agencyBucket,
+            operator,
+            productId,
+            `agency intake: credited to ${agencyBucket}`,
+            "agency_intake",
+          );
+        }
+      } catch (error) {
+        reasons.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+
+  const qty = sampleIds.length;
+  const graylog = await sendGelfMessage(
+    `thirsty agency intake: ${name} ×${qty} → bucket ${agencyBucket}`,
+    {
+      sample_intake_json: JSON.stringify({
+        productId: productId || null,
+        sampleIds,
+        name,
+        agencyBucket,
+        qty,
+        note: note || undefined,
+        intakeAt: now,
+      }),
+      sample_event: "agency_intake",
+      agency_bucket: agencyBucket,
+      product_id: productId || undefined,
+      qty_num: qty,
+      sample_source: "skill-agency-intake",
+    },
+  );
+
+  const where = [qty ? "Postgres" : "", graylog ? "Graylog" : ""]
+    .filter(Boolean).join(" + ") || "nothing";
+  const warn = reasons.length
+    ? ` WARNING: ${reasons.length} unit(s) failed: ${reasons.join("; ")}.`
+    : "";
+  return {
+    ok: qty > 0 || graylog,
+    productId: productId || null,
+    name,
+    agencyBucket,
+    qty,
+    sampleIds,
+    postgres: {
+      created,
+      updated,
+      reason: reasons.length ? reasons.join("; ") : undefined,
+    },
+    graylog,
+    message: `Agency intake: ${qty} × ${name} credited to bucket "${agencyBucket}" (recorded to ${where}).${warn}`,
+  };
+}
+
+// Fulfillment — assign one unit to a creator: moves it to CHECKED OUT
+// (checked_out_to = creator, the exact field-set the tracker's useCheckOut
+// writes), attaches a matched campaign, records a `check_out` transaction, emits
+// a `sample_assignment_json` Graylog event, and returns an enrichment note
+// (bundle membership + configured goal/promo).
+export async function recordSampleAssignment(
+  input: AssignmentInput,
+): Promise<AssignmentResult> {
+  const creator = String(input.creator || "").trim();
+  if (!creator) {
+    throw new Error("creator is required — which creator to assign this sample to?");
+  }
+
+  const row = await resolveSampleRow(input, { preferReserved: true });
+  const sampleId = row ? Number(row.id) : null;
+  const productId = productIdOf(row, input);
+  const name = row ? String(row.name ?? "").trim() || null : null;
+  const fromStatus = row ? String(row.status ?? "").trim() || null : null;
+  const agencyBucket = String(input.agencyBucket || "").trim() ||
+    (fromStatus === "reserved" && row
+      ? String(row.checked_out_to ?? "").trim() || null
+      : null);
+  const now = new Date().toISOString();
+  const note = String(input.note || "").trim();
+  const operator = String(input.operator || "").trim();
+
+  const campaignEntry = matchCampaign(productId, name);
+  const campaign = String(input.campaign || "").trim() ||
+    (campaignEntry ? campaignEntry.name : null);
+  const campaignId = String(input.campaignId || "").trim() ||
+    (campaignEntry ? campaignEntry.id : "");
+
+  let updated = false;
+  let transactionId: number | null = null;
+  const reasons: string[] = [];
+  if (row) {
+    try {
+      await Samples.update(String(row.id), {
+        status: "checked_out",
+        checked_out_to: creator,
+        checked_out_at: now,
+      });
+      updated = true;
+    } catch (error) {
+      reasons.push(error instanceof Error ? error.message : String(error));
+    }
+  } else {
+    reasons.push("no matching sample row in Postgres (Graylog event still written)");
+  }
+
+  const enrichment = await buildEnrichment(row, campaignEntry);
+
+  if (row) {
+    try {
+      const summary = `assigned to ${creator}${
+        agencyBucket ? ` from bucket ${agencyBucket}` : ""
+      }${campaign ? ` | campaign ${campaign}` : ""}${note ? ` | ${note}` : ""}${
+        enrichment.length ? ` | ${enrichment.join(" ")}` : ""
+      }`;
+      const tx = await InventoryTransactions.create({
+        action: "check_out",
+        sample_id: row.id,
+        operator: operator || null,
+        checked_out_to: creator,
+        scanned_code: productId || null,
+        notes: summary,
+      }) as SampleRow | undefined;
+      transactionId = tx && tx.id != null ? Number(tx.id) : null;
+    } catch (error) {
+      reasons.push(
+        `transaction: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  const graylog = await sendGelfMessage(
+    `thirsty sample assigned: ${name ?? productId ?? "sample"} → ${creator}`,
+    {
+      sample_assignment_json: JSON.stringify({
+        productId,
+        sampleId,
+        name,
+        creator,
+        agencyBucket: agencyBucket || undefined,
+        campaign: campaign || undefined,
+        campaignId: campaignId || undefined,
+        fromStatus,
+        assignedAt: now,
+        note: note || undefined,
+      }),
+      creator,
+      sample_status: "checked_out",
+      sample_event: "assigned",
+      product_id: productId ?? undefined,
+      sample_id: sampleId != null ? String(sampleId) : undefined,
+      agency_bucket: agencyBucket || undefined,
+      campaign: campaign || undefined,
+      campaign_id: campaignId || undefined,
+      sample_source: "skill-assignment",
+    },
+  );
+
+  const targets: string[] = [];
+  if (updated) targets.push("Postgres");
+  if (graylog) targets.push("Graylog");
+  const where = targets.length ? targets.join(" + ") : "nothing";
+  const warnings: string[] = [];
+  if (!graylog) warnings.push("Graylog assignment event was NOT written");
+  if (updated && transactionId === null) {
+    warnings.push("the check-out transaction was NOT recorded");
+  }
+  const warn = warnings.length ? ` WARNING: ${warnings.join("; ")}.` : "";
+
+  return {
+    ok: updated || graylog,
+    sampleId,
+    productId,
+    name,
+    creator,
+    fromStatus,
+    agencyBucket: agencyBucket || null,
+    campaign: campaign || null,
+    enrichment,
+    postgres: {
+      updated,
+      transactionId,
+      reason: reasons.length ? reasons.join("; ") : undefined,
+    },
+    graylog,
+    message: `Assigned ${name ?? productId ?? "sample"} to ${creator} — checked out${
+      campaign ? `, campaign "${campaign}"` : ""
+    } (persisted to ${where}).${warn}${
+      enrichment.length ? " " + enrichment.join(" ") : ""
+    }`,
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -26,13 +26,16 @@ import {
 } from "./core/samples.ts";
 import {
   listSampleStatuses,
+  recordAgencyIntake,
   recordBulkSampleSold,
+  recordSampleAssignment,
   recordSampleListing,
   recordSampleSold,
   recordSampleStatus,
 } from "./core/lifecycle.ts";
 import {
   envValue,
+  fetchCreatorsForProduct,
   fetchKnownCreators,
   graylogConfigFromEnv,
 } from "./core/graylog.ts";
@@ -1328,6 +1331,33 @@ export async function legacyHandler(req: Request): Promise<Response> {
         return json({ creators: await fetchKnownCreators(limit) });
       }
 
+      // Creators who ordered a given product (the derived assigned-creator
+      // dropdown). ?all=1 unions in every known creator so an admin can also
+      // assign someone who hasn't ordered it yet. Derived from affiliate-export
+      // (the only source with product_id + creator) — see fetchCreatorsForProduct.
+      if (pathname === "/api/product-creators") {
+        const productId = (url.searchParams.get("productId") ||
+          url.searchParams.get("product") || "").trim();
+        if (!productId) {
+          return json({ ok: false, error: "productId is required" }, 400);
+        }
+        const raw = Number(url.searchParams.get("limit"));
+        const limit = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 1000;
+        const ordered = await fetchCreatorsForProduct(productId, limit);
+        const all = url.searchParams.get("all") === "1"
+          ? await fetchKnownCreators(limit)
+          : undefined;
+        return json({
+          productId,
+          orderedCreators: ordered,
+          ...(all
+            ? { allKnown: all, creators: [...new Set([...ordered, ...all])] }
+            : { creators: ordered }),
+          note:
+            "orderedCreators are derived from affiliate-export, where `creator` is the agency label (not necessarily a TikTok @handle).",
+        });
+      }
+
       // Update a sample's status (rejects "sold" — that goes through the sold
       // flow so revenue is attributed to a creator). Validation failures return
       // a clean 400 (not the outer 500 + stack) so the MCP surfaces the reason.
@@ -1380,6 +1410,34 @@ export async function legacyHandler(req: Request): Promise<Response> {
         }
         try {
           return json(await recordBulkSampleSold(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // Agency intake: credit a bulk lot of one product to an agency bucket
+      // (reserved), before any creator is assigned.
+      if (pathname === "/api/agency-intake") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordAgencyIntake(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // Fulfillment: assign a unit to a creator → checked out (+ campaign match
+      // + enrichment note). Returns the note for the admin.
+      if (pathname === "/api/sample-assign") {
+        if (req.method !== "POST") {
+          return json({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return json(await recordSampleAssignment(await readJsonBody(req)));
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return json({ ok: false, error: msg }, 400);

--- a/mcp/thirsty-samples/server.ts
+++ b/mcp/thirsty-samples/server.ts
@@ -309,6 +309,84 @@ const TOOLS = [
       additionalProperties: false,
     },
   },
+  {
+    name: "list_product_creators",
+    description:
+      "The DERIVED assigned-creator candidate list for a product: creators who " +
+      "ordered it (from affiliate-export). Use this to populate the 'which " +
+      "creator?' choice for assign_sample. Pass includeAllKnown to also offer " +
+      "creators who haven't ordered it. Note: ordered-creator values come from " +
+      "affiliate-export where `creator` is the AGENCY label, not necessarily a " +
+      "TikTok @handle.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        productId: {
+          type: "string",
+          description: "TikTok productId / qr_code to find creators for.",
+        },
+        includeAllKnown: {
+          type: "boolean",
+          description: "Also union in every known creator (default false).",
+        },
+        limit: { type: "number", description: "Max creators (default 1000)." },
+      },
+      required: ["productId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agency_intake",
+    description:
+      "Credit a BULK lot of one product to an agency bucket (e.g. admin 'kyle') " +
+      "before any creator is assigned — the units sit in 'reserved'. Use " +
+      "`productId` + `qty` for a fresh shipment (creates that many reserved " +
+      "units), or `sampleIds` to credit existing units. Later, assign_sample " +
+      "moves a unit from the bucket to a creator.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        productId: { type: "string", description: "TikTok productId / qr_code." },
+        name: { type: "string", description: "Product name (else derived/uses productId)." },
+        qty: { type: ["number", "string"], description: "How many units arrived (with productId). Default 1, max 200." },
+        sampleIds: {
+          type: "array",
+          description: "Credit these existing sample ids instead of creating new ones.",
+          items: { type: ["string", "number"] },
+        },
+        agencyBucket: { type: "string", description: "Bucket/admin to credit, e.g. 'kyle'." },
+        operator: { type: "string", description: "Who recorded the intake." },
+        note: { type: "string", description: "Optional note." },
+      },
+      required: ["agencyBucket"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "assign_sample",
+    description:
+      "Assign/fulfill a sample to a creator — moves one unit to CHECKED OUT " +
+      "(checked_out_to = creator), pulling from the agency bucket if it's " +
+      "reserved, attaching a matched campaign, and returning an enrichment note " +
+      "(bundle membership + the campaign's daily-video goal + any promo). " +
+      "Confirm the creator against list_product_creators for that product first. " +
+      "Prefer a specific sampleId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sampleId: { type: ["string", "number"], description: "Sample's Postgres id (preferred)." },
+        productId: { type: "string", description: "TikTok productId / qr_code (if sampleId omitted)." },
+        creator: { type: "string", description: "Creator @handle to assign to." },
+        agencyBucket: { type: "string", description: "Bucket it came from (else inferred from a reserved unit)." },
+        campaign: { type: "string", description: "Campaign name (else auto-matched from config)." },
+        campaignId: { type: "string", description: "Campaign id (optional)." },
+        operator: { type: "string", description: "Who performed the assignment." },
+        note: { type: "string", description: "Optional note." },
+      },
+      required: ["creator"],
+      additionalProperties: false,
+    },
+  },
 ];
 
 const server = new Server(
@@ -422,6 +500,47 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             orderRef: args.orderRef,
             note: args.note,
             force: args.force,
+          },
+        });
+        break;
+      }
+
+      case "list_product_creators": {
+        const q = new URLSearchParams({ productId: String(args.productId ?? "") });
+        if (args.includeAllKnown) q.set("all", "1");
+        if (args.limit) q.set("limit", String(args.limit));
+        result = await api(`/api/product-creators?${q.toString()}`);
+        break;
+      }
+
+      case "agency_intake": {
+        result = await api("/api/agency-intake", {
+          method: "POST",
+          body: {
+            productId: args.productId,
+            name: args.name,
+            qty: args.qty,
+            sampleIds: args.sampleIds,
+            agencyBucket: args.agencyBucket,
+            operator: args.operator,
+            note: args.note,
+          },
+        });
+        break;
+      }
+
+      case "assign_sample": {
+        result = await api("/api/sample-assign", {
+          method: "POST",
+          body: {
+            sampleId: args.sampleId,
+            productId: args.productId,
+            creator: args.creator,
+            agencyBucket: args.agencyBucket,
+            campaign: args.campaign,
+            campaignId: args.campaignId,
+            operator: args.operator,
+            note: args.note,
           },
         });
         break;


### PR DESCRIPTION
## What

Finishes the lifecycle: **assign a sample to a creator**, **agency-bucket bulk intake + fulfillment**, a **derived assigned-creator dropdown**, and an **enrichment note** on assignment. Follow-up to #74/#75/#76.

## How (zero migration — reuses existing columns)

- **Assign / fulfill** (`assign_sample` → `POST /api/sample-assign`): moves a unit to `checked_out` with `checked_out_to=<creator>`/`checked_out_at` (the exact field-set the tracker's `useCheckOut` writes) + a `check_out` transaction + a `sample_assignment_json` Graylog event. Auto-matches a campaign and returns an **enrichment note**.
- **Agency intake** (`agency_intake` → `POST /api/agency-intake`): credits a bulk lot to an agency bucket (e.g. `kyle`) — units sit in `reserved` with `checked_out_to=<bucket>`. `productId`+`qty` creates N reserved units; `sampleIds` credits existing ones. Emits `sample_intake_json`. Fulfillment pulls a `reserved` bucket unit first.
- **Derived dropdown** (`list_product_creators` → `GET /api/product-creators`): `fetchCreatorsForProduct` queries `tiktok-affiliate-export` (the only source with `product_id`+`creator`) for creators who ordered the product; `?all=1` unions in all known creators. Labelled with the agency-label caveat.
- **Enrichment note** — honest about provenance: **bundle membership is REAL** (`samples.bundle_id` → bundles + siblings); **campaign daily-video goal + promo are CONFIG** (`core/campaign-config.json`), labelled `[from campaign-config]`. No goal/promo data is fabricated — there's no source for it yet.

### Changes
- `core/graylog.ts` — `fetchCreatorsForProduct`.
- `core/lifecycle.ts` — `recordSampleAssignment`, `recordAgencyIntake`, `matchCampaign`/`buildEnrichment`, `resolveSampleRow` gains `preferReserved`.
- `core/campaign-config.json` — campaign/goal/promo config (the one stub, clearly flagged).
- `main.ts` — `GET /api/product-creators`, `POST /api/agency-intake`, `POST /api/sample-assign`.
- `mcp/thirsty-samples/server.ts` — `list_product_creators`, `agency_intake`, `assign_sample` (now 10 tools).
- skill docs — Workflows 5 (agency intake) & 6 (assign/fulfill), Events 4 & 5, flow diagram updated; `creator_id`-at-intake item resolved (creator set via `assign_sample`).

## Verification
- `deno check` clean across `core/lifecycle.ts`, `main.ts`, MCP server.
- MCP `tools/list` returns 10 tools incl. the 3 new ones.
- Live validation: the 3 new endpoints return clean 400s for missing required fields; `/api/product-creators` returns the derived structure + caveat.

## Gaps (documented, out of scope)
- Order-list/order-received scrape carries no `productId`/`creator`, so it can't feed the dropdown directly — creators-for-product derive from affiliate-export instead. Needs a tok-scrape change.
- Campaign/goal/promo have no real data source — config-driven until one exists. Optional `campaigns` table migration noted in the build plan if first-class campaign reporting is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
