### PR TITLE
Samples-Import backend + scrapecreators-api skill

### DIFF
--- a/.claude/skills/scrapecreators-api/SKILL.md
+++ b/.claude/skills/scrapecreators-api/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: scrapecreators-api
+description: >-
+  Answer TikTok Shop product questions DURING SAMPLE INTAKE via the connected
+  ScrapeCreators MCP server. Trigger when, while intaking or looking at a sample,
+  the user asks about a product's REVIEWS ("what are the reviews like for this
+  product", "is it any good", "what's the rating", "any complaints") or about a
+  creator's OTHER / SIMILAR products ("what similar products are in their
+  showcase", "what else does @x promote", "what's in their storefront"). The
+  inputs are already on hand at intake: the sample's TikTok Shop PDP url or its
+  numeric productId (= the sample's qr_code), and the creator @handle. Read-only
+  product research — it does NOT write sample state; lifecycle writes
+  (status/assign/sold/listing) are the sample-lifecycle skill's job.
+allowed-tools: mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_shop_product_reviews, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_product, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_user_showcase, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_shop_products, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_shop_search
+---
+
+# scrapecreators-api
+
+Product research for sample intake, backed by the **already-connected
+ScrapeCreators MCP** (tools prefixed `mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__`).
+This is the read-side companion to `sample-lifecycle`: when the user is deciding
+what to do with a sample, this answers "is this product any good?" and "what else
+does this creator push?". It never changes inventory — that's `sample-lifecycle`.
+
+You already have the inputs at intake: the TikTok Shop **PDP url** or the numeric
+**productId** (which is the sample's `qr_code`), and the **creator @handle**.
+
+## Workflow 1 — Reviews ("what are the reviews like for this product?")
+
+Call `mcp__…__v1_tiktok_shop_product_reviews` with `url` = the sample's PDP url
+(or `product_id` = the numeric `qr_code`), `region: "US"`, `page: 1`.
+
+- Headline from `rating_distribution` + `total_reviews` — e.g. "4.6★ across 1,243
+  reviews, ~78% 5-star".
+- Representative quotes from `product_reviews[].{rating, display_text,
+  sku_specification, review_timestamp_fmt}` — quote a couple of high and low ones
+  and note which variant (`sku_specification`) they bought.
+- Paginate with `page` for more.
+
+**Shortcut:** if you also want price/stock/image in the same breath, call
+`mcp__…__v1_tiktok_product` (`url` required, US-only) once — its
+`product_detail_review` (`product_rating`, `review_count`) gives a quick rating
+summary plus `related_videos` (affiliate TikToks promoting it). The reviews tool
+is still the source of truth for the full list + distribution.
+
+## Workflow 2 — Showcase / similar products ("what similar products are in their showcase?")
+
+Call `mcp__…__v1_tiktok_user_showcase` with `handle` = the creator handle
+**without the `@`** (e.g. `boosteddealsdaily`), `region: "US"`, `cursor` to page.
+
+- Read each product's `{title, price, images, shop}`; surface titles + prices,
+  and flag any that overlap or compete with the sample being intaken.
+- If the user means the **shop's** other products (not the creator's showcase),
+  use `mcp__…__v1_tiktok_shop_products` (`url` = store url, `sort_by: "top"`).
+- For similar products across TikTok Shop generally, use
+  `mcp__…__v1_tiktok_shop_search` (`query` = the product name/keywords).
+
+## Guardrails
+
+- **Read-only.** Never changes sample state — defer all writes (status, assign,
+  sold, listing) to the `sample-lifecycle` skill.
+- **Always `region: "US"`.** It's the only reliable region; `v1_tiktok_product`
+  is US-only. Non-US returns limited/inconsistent data.
+- **Reuse the id you already have.** The sample's `qr_code` IS the TikTok
+  productId — pass it (or the PDP url) directly. Don't re-search by name: a
+  name search on a bare id can bind an unrelated listing, and each lookup costs
+  a credit.
+- **Prefer these connected MCP tools** over raw curl. (data-pimp's own
+  `SCRAPECREATORS_API_KEY` paths in `core/samples.ts` / `product-image.ts` are
+  server-side enrichment, not ad-hoc Q&A.)
+- The MCP server UUID in `allowed-tools` is connection-specific; if the
+  ScrapeCreators tools stop resolving, re-confirm the server prefix.

--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -319,6 +319,44 @@ export async function fetchCreatorsForProduct(
   }
 }
 
+// Scheduled-listing intents (sample_schedule_json) paired with their fired
+// markers (sample_schedule_done_json), for the auto-list cron. 1-year window —
+// schedules are short-lived. Errors degrade to empty so the cron just no-ops.
+export async function fetchScheduleRecords(): Promise<
+  { scheduled: Record<string, unknown>[]; done: Set<string> }
+> {
+  const config = graylogConfigFromEnv();
+  if (!config) return { scheduled: [], done: new Set() };
+
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365,
+    };
+    const sched = await searchGraylog(wide, "sample_schedule_json:*", 500, [
+      "timestamp",
+      "sample_schedule_json",
+    ]);
+    const doneMsgs = await searchGraylog(
+      wide,
+      "sample_schedule_done_json:*",
+      500,
+      ["timestamp", "sample_schedule_done_json"],
+    );
+    const scheduled = sched
+      .map((m) => parseJsonValue(m.sample_schedule_json))
+      .filter(isRecord);
+    const done = new Set<string>();
+    for (const m of doneMsgs) {
+      const rec = parseJsonValue(m.sample_schedule_done_json);
+      if (isRecord(rec) && rec.scheduleId) done.add(String(rec.scheduleId));
+    }
+    return { scheduled, done };
+  } catch {
+    return { scheduled: [], done: new Set() };
+  }
+}
+
 export function graylogConfigFromEnv(): GraylogConfig | null {
   const url = normalizeGraylogUrl(
     envValue("GRAYLOG_API_URL") || envValue("GRAYLOG_URL"),

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -21,7 +21,7 @@
 // `product_id` on Graylog events. `sample_id` is stamped alongside so the two
 // systems reconcile even when a qr_code holds a barcode instead of a real id.
 
-import { sendGelfMessage } from "./graylog.ts";
+import { fetchScheduleRecords, sendGelfMessage } from "./graylog.ts";
 import { Bundles, InventoryTransactions, Samples } from "../db.ts";
 import sampleStatuses from "./sample-statuses.json" with { type: "json" };
 import campaignConfig from "./campaign-config.json" with { type: "json" };
@@ -211,6 +211,45 @@ export type AssignmentResult = {
   campaign: string | null;
   enrichment: string[];
   postgres: { updated: boolean; transactionId: number | null; reason?: string };
+  graylog: boolean;
+  message: string;
+};
+
+export type ImportInput = {
+  productId?: string;
+  qrCode?: string;
+  name?: string;
+  price?: number | string;
+  image?: string;
+  seller?: string;
+  creator?: string;
+  campaign?: string;
+  operator?: string;
+  note?: string;
+  // Optional auto-listing schedule: after `autoListAfterDays`, a cron emits a
+  // (stub) marketplace listing for this sample. e.g. 10 videos at 5/day → 2 days.
+  autoListAfterDays?: number | string;
+  marketplace?: string;
+  askPrice?: number | string;
+};
+
+export type ScheduledListing = {
+  scheduleId: string;
+  listAt: string;
+  marketplace: string;
+  askPrice: number;
+};
+
+export type ImportResult = {
+  ok: boolean;
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  creator: string;
+  campaign: string | null;
+  enrichment: string[];
+  scheduledListing: ScheduledListing | null;
+  postgres: { created: boolean; transactionId: number | null; reason?: string };
   graylog: boolean;
   message: string;
 };
@@ -1183,6 +1222,246 @@ export async function recordSampleAssignment(
       enrichment.length ? " " + enrichment.join(" ") : ""
     }`,
   };
+}
+
+// Import a product as a NEW inventory sample assigned directly to a creator —
+// the Samples-Import flow (paste/upload productIds → hydrate → assign). Creates a
+// Postgres row in `checked_out` (checked_out_to = creator), logs a `check_out`
+// transaction, matches a campaign, emits `sample_assignment_json`
+// (sample_event "imported"), and returns the enrichment note. Optionally
+// schedules a (stub) marketplace listing after N days via a `sample_schedule_json`
+// event the auto-list cron acts on.
+export async function recordSampleImport(
+  input: ImportInput,
+): Promise<ImportResult> {
+  const creator = String(input.creator || "").trim();
+  if (!creator) {
+    throw new Error("creator is required — assign the import to a creator");
+  }
+  const productId = String(input.productId ?? input.qrCode ?? "").trim();
+  if (!productId) throw new Error("productId is required");
+
+  const now = new Date().toISOString();
+  const name = String(input.name || "").trim() || productId;
+  const price = numOrZero(input.price);
+  const image = String(input.image || "").trim();
+  const seller = String(input.seller || "").trim();
+  const note = String(input.note || "").trim();
+  const operator = String(input.operator || "").trim();
+
+  // Build the row with only present columns (db.ts insertRow keeps undefined
+  // keys, so omit them rather than insert nulls for optional fields).
+  const createData: Record<string, unknown> = {
+    name,
+    qr_code: productId,
+    status: "checked_out",
+    checked_out_to: creator,
+    checked_out_at: now,
+    notes: `imported & assigned to ${creator}${note ? ` | ${note}` : ""}`,
+  };
+  if (seller) createData.brand = seller;
+  if (image) createData.picture_url = image;
+  if (price > 0) createData.current_price = price;
+
+  let sampleId: number | null = null;
+  let created = false;
+  let bundleRow: SampleRow | null = null;
+  let transactionId: number | null = null;
+  const reasons: string[] = [];
+  try {
+    const row = await Samples.create(createData) as SampleRow | undefined;
+    if (row?.id != null) {
+      sampleId = Number(row.id);
+      created = true;
+      bundleRow = row;
+    }
+  } catch (error) {
+    reasons.push(error instanceof Error ? error.message : String(error));
+  }
+
+  const campaignEntry = matchCampaign(productId, name);
+  const campaign = String(input.campaign || "").trim() ||
+    (campaignEntry ? campaignEntry.name : null);
+  const campaignId = campaignEntry ? campaignEntry.id : "";
+
+  // Optional auto-listing schedule (stub — records intent for the cron).
+  let scheduledListing: ScheduledListing | null = null;
+  const days = numOrZero(input.autoListAfterDays);
+  if (created && days > 0) {
+    const marketplace = String(input.marketplace || "ebay").trim() || "ebay";
+    const askNum = numOrZero(input.askPrice);
+    const askPrice = askNum > 0 ? askNum : (price > 0 ? round2(price) : 0);
+    const listAt = new Date(Date.now() + days * 86_400_000).toISOString();
+    const scheduleId = `sched-${crypto.randomUUID()}`;
+    const ok = await sendGelfMessage(
+      `thirsty sample listing scheduled: ${name} → ${marketplace} in ${days}d`,
+      {
+        sample_schedule_json: JSON.stringify({
+          scheduleId, productId, sampleId, name, creator, marketplace, askPrice,
+          listAt, scheduledAt: now,
+        }),
+        sample_event: "listing_scheduled",
+        schedule_id: scheduleId,
+        list_at: listAt,
+        product_id: productId,
+        sample_id: sampleId != null ? String(sampleId) : undefined,
+        creator,
+        marketplace,
+        ask_price_num: askPrice,
+        sample_source: "skill-import",
+      },
+    );
+    if (ok) scheduledListing = { scheduleId, listAt, marketplace, askPrice };
+  }
+
+  const enrichment = await buildEnrichment(bundleRow, campaignEntry);
+  if (scheduledListing) {
+    enrichment.push(
+      `Auto-listing: a draft ${scheduledListing.marketplace} listing is scheduled ` +
+        `for ${scheduledListing.listAt.slice(0, 10)} (~${days} day(s)). ` +
+        "[stub — records intent, does not post to eBay yet]",
+    );
+  }
+
+  if (created) {
+    try {
+      const summary = `imported & assigned to ${creator}${
+        campaign ? ` | campaign ${campaign}` : ""
+      }${scheduledListing ? ` | auto-list ${scheduledListing.listAt.slice(0, 10)}` : ""}${
+        note ? ` | ${note}` : ""
+      }`;
+      const tx = await InventoryTransactions.create({
+        action: "check_out",
+        sample_id: sampleId,
+        operator: operator || null,
+        checked_out_to: creator,
+        scanned_code: productId,
+        notes: summary,
+      }) as SampleRow | undefined;
+      transactionId = tx && tx.id != null ? Number(tx.id) : null;
+    } catch (error) {
+      reasons.push(
+        `transaction: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  const graylog = await sendGelfMessage(
+    `thirsty sample imported: ${name} → ${creator}`,
+    {
+      sample_assignment_json: JSON.stringify({
+        productId,
+        sampleId,
+        name,
+        creator,
+        campaign: campaign || undefined,
+        campaignId: campaignId || undefined,
+        price: price || undefined,
+        image: image || undefined,
+        seller: seller || undefined,
+        importedAt: now,
+        note: note || undefined,
+      }),
+      creator,
+      sample_status: "checked_out",
+      sample_event: "imported",
+      product_id: productId,
+      sample_id: sampleId != null ? String(sampleId) : undefined,
+      campaign: campaign || undefined,
+      campaign_id: campaignId || undefined,
+      sample_source: "skill-import",
+    },
+  );
+
+  const targets: string[] = [];
+  if (created) targets.push("Postgres");
+  if (graylog) targets.push("Graylog");
+  const where = targets.length ? targets.join(" + ") : "nothing";
+  const warnings: string[] = [];
+  if (!created) {
+    warnings.push(
+      `Postgres row was NOT created${reasons.length ? ` (${reasons.join("; ")})` : ""}`,
+    );
+  } else if (transactionId === null) {
+    warnings.push("the check-out transaction was NOT recorded");
+  }
+  if (!graylog) warnings.push("Graylog event was NOT written");
+  const warn = warnings.length ? ` WARNING: ${warnings.join("; ")}.` : "";
+
+  return {
+    ok: created || graylog,
+    sampleId,
+    productId,
+    name,
+    creator,
+    campaign: campaign || null,
+    enrichment,
+    scheduledListing,
+    postgres: {
+      created,
+      transactionId,
+      reason: reasons.length ? reasons.join("; ") : undefined,
+    },
+    graylog,
+    message: `Imported ${name} → assigned to ${creator}${
+      campaign ? `, campaign "${campaign}"` : ""
+    } (persisted to ${where}).${warn}${
+      enrichment.length ? " " + enrichment.join(" ") : ""
+    }`,
+  };
+}
+
+// Find scheduled-listing intents that are due (list_at <= now) and not yet
+// fired, for the auto-list cron. Pairs sample_schedule_json events with their
+// sample_schedule_done_json markers and returns only the unfired, due ones.
+export async function fetchDueListingSchedules(): Promise<
+  Array<
+    {
+      scheduleId: string;
+      productId: string;
+      sampleId: number | null;
+      name: string;
+      creator: string;
+      marketplace: string;
+      askPrice: number;
+      listAt: string;
+    }
+  >
+> {
+  const records = await fetchScheduleRecords();
+  const nowMs = Date.now();
+  const due = [];
+  for (const r of records.scheduled) {
+    const id = String(r.scheduleId || "").trim();
+    if (!id || records.done.has(id)) continue;
+    const listAt = String(r.listAt || "");
+    const t = Date.parse(listAt);
+    if (!Number.isFinite(t) || t > nowMs) continue;
+    due.push({
+      scheduleId: id,
+      productId: String(r.productId || ""),
+      sampleId: r.sampleId != null ? Number(r.sampleId) : null,
+      name: String(r.name || ""),
+      creator: String(r.creator || ""),
+      marketplace: String(r.marketplace || "ebay"),
+      askPrice: numOrZero(r.askPrice),
+      listAt,
+    });
+  }
+  return due;
+}
+
+// Mark a scheduled listing as fired so the at-least-once cron doesn't re-list it.
+export async function markListingScheduleDone(scheduleId: string): Promise<void> {
+  await sendGelfMessage(`thirsty sample listing fired: ${scheduleId}`, {
+    sample_schedule_done_json: JSON.stringify({
+      scheduleId,
+      firedAt: new Date().toISOString(),
+    }),
+    sample_event: "listing_fired",
+    schedule_id: scheduleId,
+    sample_source: "skill-cron",
+  });
 }
 
 // Human-readable outcome line. Honest about partial success: a Graylog write can

--- a/main.ts
+++ b/main.ts
@@ -25,10 +25,13 @@ import {
   upsertSampleProduct,
 } from "./core/samples.ts";
 import {
+  fetchDueListingSchedules,
   listSampleStatuses,
+  markListingScheduleDone,
   recordAgencyIntake,
   recordBulkSampleSold,
   recordSampleAssignment,
+  recordSampleImport,
   recordSampleListing,
   recordSampleSold,
   recordSampleStatus,
@@ -1335,11 +1338,13 @@ export async function legacyHandler(req: Request): Promise<Response> {
       // dropdown). ?all=1 unions in every known creator so an admin can also
       // assign someone who hasn't ordered it yet. Derived from affiliate-export
       // (the only source with product_id + creator) — see fetchCreatorsForProduct.
+      // CORS — read cross-origin by the Samples-Import demo (easierbycode.com).
       if (pathname === "/api/product-creators") {
+        if (req.method === "OPTIONS") return corsPreflight();
         const productId = (url.searchParams.get("productId") ||
           url.searchParams.get("product") || "").trim();
         if (!productId) {
-          return json({ ok: false, error: "productId is required" }, 400);
+          return corsJson({ ok: false, error: "productId is required" }, 400);
         }
         const raw = Number(url.searchParams.get("limit"));
         const limit = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 1000;
@@ -1347,7 +1352,7 @@ export async function legacyHandler(req: Request): Promise<Response> {
         const all = url.searchParams.get("all") === "1"
           ? await fetchKnownCreators(limit)
           : undefined;
-        return json({
+        return corsJson({
           productId,
           orderedCreators: ordered,
           ...(all
@@ -1441,6 +1446,21 @@ export async function legacyHandler(req: Request): Promise<Response> {
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           return json({ ok: false, error: msg }, 400);
+        }
+      }
+
+      // Import a product as a NEW sample assigned to a creator — the
+      // Samples-Import demo loop. Called cross-origin (easierbycode.com) → CORS.
+      if (pathname === "/api/sample-import") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "POST") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return corsJson(await recordSampleImport(await readJsonBody(req)));
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return corsJson({ ok: false, error: msg }, 400);
         }
       }
 
@@ -1578,6 +1598,62 @@ function renderMemberUnavailable(): Response {
   </body>
 </html>`;
   return new Response(html, { status: 503, headers });
+}
+
+// Auto-list scheduled samples: hourly, fire any due `sample_schedule_json`
+// intents (recorded by recordSampleImport's auto-list option) as a STUB eBay
+// draft listing + a status flip to `cleared_to_sell`, then mark them done so the
+// at-least-once cron doesn't re-list. Only the central deployment (DATABASE_URL +
+// Graylog) runs it; a thin client no-ops. NOTE: "draft eBay listing" is a stub —
+// recordSampleListing records a Graylog listing intent; nothing posts to eBay.
+// `Deno.cron` is stable on Deno Deploy at runtime but gated behind the unstable
+// type lib for `deno check`; feature-detect + cast so the type-check passes and
+// runtimes without cron skip gracefully.
+const denoCron = (Deno as unknown as {
+  cron?: (
+    name: string,
+    schedule: string,
+    handler: () => void | Promise<void>,
+  ) => void;
+}).cron;
+if (denoCron) {
+  denoCron("thirsty-sample-auto-list", "0 * * * *", async () => {
+    if (REMOTE_API) return; // thin client: the central deploy owns the cron
+    try {
+      const due = await fetchDueListingSchedules();
+      for (const s of due) {
+        try {
+          if (s.askPrice > 0) {
+            await recordSampleListing({
+              sampleId: s.sampleId ?? undefined,
+              productId: s.productId,
+              creator: s.creator,
+              marketplace: s.marketplace,
+              askPrice: s.askPrice,
+              note: "auto-listed (scheduled draft — not posted to eBay)",
+            });
+            await recordSampleStatus({
+              sampleId: s.sampleId ?? undefined,
+              productId: s.productId,
+              status: "cleared_to_sell",
+              source: "skill-cron",
+              note: `auto-list fired (${s.marketplace})`,
+            });
+          }
+          await markListingScheduleDone(s.scheduleId); // always: avoid re-firing
+        } catch (e) {
+          console.error("[auto-list] schedule", s.scheduleId, "failed:", e);
+        }
+      }
+      if (due.length) {
+        console.log(`[auto-list] fired ${due.length} scheduled listing(s)`);
+      }
+    } catch (e) {
+      console.error("[auto-list] cron error:", e);
+    }
+  });
+} else {
+  console.error("[auto-list] Deno.cron unavailable — auto-listing won't fire");
 }
 
 Deno.serve({ port: Number(Deno.env.get("PORT")) || 8000 }, (req) => {

--- a/static/os.js
+++ b/static/os.js
@@ -230,6 +230,21 @@ const FOLDERS = [
         height: 780,
       },
       {
+        id: "samples-import",
+        name: "Samples-Import",
+        icon: ICONS.mobile,
+        // Admin import tool: paste/upload a list of TikTok productIds, hydrate
+        // each, and add to inventory assigned to a creator. Reuses the Samples
+        // demo's order-modal preview; calls the live thirsty.store import API.
+        url: "https://easierbycode.com/tok-scrape/samples-import/www/",
+        allow: "fullscreen",
+        external: true,
+        // Wider than the phone Samples demo (paste box + creator picker +
+        // auto-list panel) and resizable — not mobile-locked.
+        width: 520,
+        height: 840,
+      },
+      {
         id: "content-by-sample",
         name: "Content by Sample",
         icon: ICONS.content,


### PR DESCRIPTION
## What

Backend + skill for the **Samples-Import** demo, plus the **scrapecreators-api** intake skill. Pairs with the UI PR in `easierbycode/tok-scrape`.

## Changes

- **`core/lifecycle.ts` — `recordSampleImport`**: create a NEW inventory sample assigned directly to a creator (`status=checked_out`, `checked_out_to=<creator>`, `check_out` transaction, `sample_assignment_json` event with `sample_event:"imported"`). Returns the enrichment note (real **bundle** membership from `samples.bundle_id` + config campaign **goal/promo**). Optional `autoListAfterDays` records a `sample_schedule_json` listing intent.
- **`core/graylog.ts`**: `fetchScheduleRecords` (pairs `sample_schedule_json` intents with their `sample_schedule_done_json` fired-markers).
- **`core/lifecycle.ts`**: `fetchDueListingSchedules` + `markListingScheduleDone` for the cron.
- **`main.ts`**:
  - `POST /api/sample-import` — **CORS-enabled** (OPTIONS preflight + `corsJson`), so the GH-Pages demo on `easierbycode.com` can call it cross-origin.
  - `/api/product-creators` — now **CORS-enabled** (for the import page's creator picker).
  - **`Deno.cron` auto-list** (hourly): fires due scheduled listings as a **stub** (`recordSampleListing` Graylog intent + `cleared_to_sell` status), `markListingScheduleDone` for at-least-once idempotency. Feature-detected (`Deno.cron` is unstable-typed; cast so `deno check` passes and runtimes without cron skip gracefully). Central deploy only.
- **`static/os.js`**: register the `samples-import` Thirsty OS demo (iframe → `easierbycode.com/tok-scrape/samples-import/www/`).
- **`.claude/skills/scrapecreators-api/SKILL.md`**: intake skill — "what are the reviews like for this product" / "what's in their showcase / similar products" → routed to the already-connected ScrapeCreators MCP (`v1_tiktok_shop_product_reviews` / `v1_tiktok_product` / `v1_tiktok_user_showcase` / `v1_tiktok_shop_products` / `v1_tiktok_shop_search`). Read-only; defers writes to `sample-lifecycle`.

## Honest stubs / notes
- **No eBay API.** "Auto-list draft" = `list_on_marketplace` Graylog intent + status flip; nothing posts to eBay. Clearly labelled in the UI + note.
- `Deno.cron` runs on Deno Deploy; locally it's unavailable without `--unstable-cron` (logs "unavailable" and skips — no crash).

## Verification
- `deno check` clean (0 TS errors).
- Live local tests: `/api/sample-import` OPTIONS preflight returns `Access-Control-Allow-Origin: *`; missing-field POSTs return CORS'd 400s; `/api/product-creators` carries CORS; cron feature-detect logs cleanly at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
