### PR TITLE
Warehouse role + order-scrape dropdown + samples-import install skill

### DIFF
--- a/.claude/skills/samples-import/SKILL.md
+++ b/.claude/skills/samples-import/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: samples-import
+description: >-
+  Open the tok-scrape Samples-Import page (paste/upload TikTok product IDs →
+  hydrate → add to inventory assigned to a creator) and, when needed, help the
+  user install the tok-scrape Chrome extension. Trigger when the user wants to
+  import sample product IDs, open Samples-Import, scrape TikTok order/seller
+  pages, or download/install the tok-scrape extension. Two load paths: the
+  Claude-in-Chrome browser skill, or the installed tok-scrape extension; the
+  install help (download chrome.zip / load-unpacked) surfaces in a Thirsty OS
+  window or a browser tab.
+allowed-tools: mcp__Claude_in_Chrome__list_connected_browsers, mcp__Claude_in_Chrome__navigate, mcp__Claude_in_Chrome__find, mcp__Claude_in_Chrome__javascript_tool, mcp__Claude_in_Chrome__get_page_text
+---
+
+# samples-import
+
+Gets the user into the **Samples-Import** workflow, by whichever path is
+available, and helps install the **tok-scrape** Chrome extension if they want the
+scraper. Samples-Import itself is a standalone page — it needs no extension; the
+extension is for scraping TikTok order/seller pages into Graylog.
+
+Key URLs:
+- Samples-Import page: `https://easierbycode.com/tok-scrape/samples-import/www/`
+  (also a Thirsty OS app: **Demos → Samples-Import**)
+- Extension install help: `https://thirsty.store/install` (also **Apps → Install
+  Extension** in Thirsty OS) — has the download + load-unpacked steps.
+- Extension zip (direct): `https://easierbycode.com/tok-scrape/chrome.zip`
+
+## Branch A — load via the Claude-in-Chrome browser skill (preferred)
+
+When a Chrome browser is connected:
+1. `list_connected_browsers` → pick the Chrome.
+2. `navigate` to the Samples-Import URL.
+3. Drive it with `find` / `javascript_tool` / `get_page_text` (paste the product
+   IDs into `#ids`, set `#creator`, optionally the auto-list panel, click
+   `#start`). The page calls the live `/api/sample-import` itself.
+
+If the Chrome extension isn't connected, ask the user to install/connect it
+rather than falling through to slower tooling.
+
+## Branch B — load via Thirsty OS / the extension
+
+- **In Thirsty OS:** open **Demos → Samples-Import** (the registered app), or
+  **Apps → Install Extension** for the install window.
+- **With the tok-scrape extension installed:** the extension adds its scrape
+  button on TikTok pages; Samples-Import still opens as the page above. The
+  extension is what makes order/seller scrapes flow to Graylog (and now stamps
+  `_creator` on order scrapes — see extension-seller).
+
+## Install the extension (download zip / load unpacked)
+
+Surface the install help as a **Thirsty OS window** (Apps → Install Extension)
+or, via the browser skill, `navigate` to `https://thirsty.store/install`. That
+page walks:
+1. **Download** `chrome.zip` (`https://easierbycode.com/tok-scrape/chrome.zip`).
+2. Unzip → open `chrome://extensions` → enable **Developer mode** → **Load
+   unpacked** → pick the folder.
+
+**CRX caveat — be explicit:** Chrome blocks `.crx` installs from outside the Web
+Store for normal profiles, so there is **no `.crx`** to "install" directly; the
+supported path is the **`.zip` + Load unpacked** flow above. (Enterprise
+force-install policy is the only exception.) Don't promise a one-click `.crx`.
+
+## Guardrails
+
+- **Downloading is an explicit-permission action** — confirm before triggering a
+  download or opening the install flow.
+- Samples-Import works **without** the extension (via Branch A); only offer the
+  install when the user wants the scraper or asks for it.
+- This skill loads/installs; the actual import writes are the page's
+  `/api/sample-import` calls (see the `sample-lifecycle` skill for the lifecycle
+  events). Reviews/showcase questions are the `scrapecreators-api` skill.

--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -319,6 +319,47 @@ export async function fetchCreatorsForProduct(
   }
 }
 
+// Buyer/creator display-names who have an ORDER for a product, matched by product
+// NAME. Order-detail scrapes (source:tiktok-bookmarklet-orders) now stamp
+// `_creator` (a display name — see extension-seller/scrape-order.js) and carry
+// `_default_product` (the product name) but NO numeric product_id, so this is a
+// fuzzy name match — distinct from fetchCreatorsForProduct's affiliate-export id
+// match. Values are display-name form (not @handles); label them as such.
+export async function fetchOrderCreatorsByName(
+  productName: string,
+  limit = 1000,
+): Promise<string[]> {
+  const config = graylogConfigFromEnv();
+  const name = String(productName || "").trim();
+  if (!config || !name) return [];
+
+  const escaped = name.replace(/"/g, '\\"');
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 1000;
+
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365 * 2,
+    };
+    const messages = await searchGraylog(
+      wide,
+      `source:tiktok-bookmarklet-orders AND creator:* AND default_product:"${escaped}"`,
+      Math.max(200, Math.min(safeLimit, 1000)),
+      ["timestamp", "creator", "default_product"],
+    );
+    const seen = new Set<string>();
+    for (const message of messages) {
+      const creator = typeof message.creator === "string"
+        ? message.creator.trim()
+        : "";
+      if (creator) seen.add(creator);
+    }
+    return [...seen].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
 // Scheduled-listing intents (sample_schedule_json) paired with their fired
 // markers (sample_schedule_done_json), for the auto-list cron. 1-year window —
 // schedules are short-lived. Errors degrade to empty so the cron just no-ops.

--- a/main.ts
+++ b/main.ts
@@ -40,6 +40,7 @@ import {
   envValue,
   fetchCreatorsForProduct,
   fetchKnownCreators,
+  fetchOrderCreatorsByName,
   graylogConfigFromEnv,
 } from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
@@ -439,6 +440,10 @@ function renderOSShell(): Response {
         <span class="brand"><span class="brand-mark">◆</span> Thirsty&nbsp;OS</span>
         <span id="active-app" class="active-app" aria-live="polite" aria-atomic="true">Finder</span>
         <span id="menubar-status" class="mb-status"></span>
+        <select id="role-switch" class="role-switch" aria-label="Profile" title="Switch profile">
+          <option value="dj">DJ</option>
+          <option value="ka">Karl · Warehouse</option>
+        </select>
       </div>
       <div id="dock" class="dock" aria-label="Dock"></div>
       <div class="taskbar-right">
@@ -778,6 +783,12 @@ export async function legacyHandler(req: Request): Promise<Response> {
   // Product Analysis dashboard (migrated from the kiosk) + its assets.
   if (pathname === "/inventory" || pathname === "/inventory.html") {
     return await serveLocalFile("./static/inventory.html", "text/html; charset=utf-8");
+  }
+  // tok-scrape extension install help (download chrome.zip + load-unpacked).
+  // Same-origin so the OS opens it in a normal (unsandboxed) window and the
+  // download link works. Surfaced by the samples-import skill / the Apps folder.
+  if (pathname === "/install" || pathname === "/install.html") {
+    return await serveLocalFile("./static/install.html", "text/html; charset=utf-8");
   }
   if (pathname === "/ui.js") {
     return await serveLocalFile("./static/ui.js", "text/javascript; charset=utf-8");
@@ -1348,18 +1359,27 @@ export async function legacyHandler(req: Request): Promise<Response> {
         }
         const raw = Number(url.searchParams.get("limit"));
         const limit = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 1000;
+        // Optional product name → also include creators who ORDERED it (order
+        // scrapes carry a display-name `_creator` + `_default_product` but no
+        // numeric product_id, so it's a name match — see fetchOrderCreatorsByName).
+        const name = (url.searchParams.get("name") || "").trim();
         const ordered = await fetchCreatorsForProduct(productId, limit);
+        const orderCreators = name
+          ? await fetchOrderCreatorsByName(name, limit)
+          : [];
         const all = url.searchParams.get("all") === "1"
           ? await fetchKnownCreators(limit)
           : undefined;
+        const merged = [
+          ...new Set([...ordered, ...orderCreators, ...(all || [])]),
+        ];
         return corsJson({
           productId,
           orderedCreators: ordered,
-          ...(all
-            ? { allKnown: all, creators: [...new Set([...ordered, ...all])] }
-            : { creators: ordered }),
+          orderCreators,
+          ...(all ? { allKnown: all, creators: merged } : { creators: merged }),
           note:
-            "orderedCreators are derived from affiliate-export, where `creator` is the agency label (not necessarily a TikTok @handle).",
+            "orderedCreators come from affiliate-export (creator = agency label); orderCreators come from order scrapes matched by product name (creator = buyer display name) — neither is guaranteed to be a TikTok @handle.",
         });
       }
 

--- a/static/install.html
+++ b/static/install.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <title>Install · tok-scrape extension</title>
+    <style>
+      :root { --bg:#0b0d11; --panel:#14181f; --line:#2a313d; --text:#f5f7f9; --muted:#8b95a4; --accent:#e8650a; --accent-soft:rgba(232,101,10,.16); }
+      * { box-sizing: border-box; }
+      body { margin:0; font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; background:var(--bg); color:var(--text); -webkit-font-smoothing:antialiased; }
+      .wrap { max-width:560px; margin:0 auto; padding:22px 18px 44px; }
+      .hd { display:flex; align-items:center; gap:12px; margin-bottom:8px; }
+      .logo { width:40px; height:40px; border-radius:12px; flex-shrink:0; display:grid; place-items:center; background:linear-gradient(150deg,#ed8740,var(--accent)); box-shadow:0 6px 18px rgba(232,101,10,.35); font-weight:700; color:#06130d; }
+      h1 { margin:0; font-size:19px; }
+      .sub { color:var(--muted); font-size:13px; margin:2px 0 18px; }
+      .card { background:var(--panel); border:1px solid var(--line); border-radius:14px; padding:16px; margin-bottom:14px; }
+      .btn { display:inline-flex; align-items:center; gap:8px; text-decoration:none; font-weight:700; font-size:15px; border-radius:10px; padding:12px 18px; }
+      .primary { color:#06130d; background:linear-gradient(150deg,#ed8740,var(--accent)); box-shadow:0 8px 22px rgba(232,101,10,.3); }
+      .ghost { color:var(--text); background:rgba(255,255,255,.06); border:1px solid var(--line); }
+      ol { margin:6px 0 0; padding-left:20px; line-height:1.85; font-size:14px; }
+      code { background:#0d1016; border:1px solid var(--line); border-radius:6px; padding:2px 7px; font-size:12.5px; }
+      .note { color:var(--accent); font-size:12.5px; background:var(--accent-soft); border:1px solid rgba(232,101,10,.3); border-radius:8px; padding:9px 11px; margin-top:12px; }
+      .muted { color:var(--muted); font-size:12.5px; }
+      h2 { font-size:14px; margin:0 0 8px; color:var(--muted); text-transform:uppercase; letter-spacing:.6px; }
+      .row { display:flex; gap:10px; flex-wrap:wrap; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="hd">
+        <div class="logo">TS</div>
+        <div><h1>Install the tok-scrape extension</h1></div>
+      </div>
+      <p class="sub">The Chrome extension scrapes TikTok Shop seller/order pages into Graylog (order list, product analytics, LIVE). It also powers Samples-Import alongside the Claude browser skill.</p>
+
+      <div class="card">
+        <h2>1 · Download</h2>
+        <div class="row">
+          <a class="btn primary" href="https://easierbycode.com/tok-scrape/chrome.zip" download="tok-scrape-extension.zip">Download chrome.zip</a>
+          <a class="btn ghost" href="https://easierbycode.com/tok-scrape/samples-import/www/" target="_blank" rel="noopener">Open Samples-Import</a>
+        </div>
+        <p class="muted" style="margin-top:10px">Direct link: <code>easierbycode.com/tok-scrape/chrome.zip</code></p>
+      </div>
+
+      <div class="card">
+        <h2>2 · Load it (unpacked)</h2>
+        <ol>
+          <li>Unzip <code>chrome.zip</code> to a folder.</li>
+          <li>Open <code>chrome://extensions</code> (paste it into the address bar — pages can't link to <code>chrome://</code>).</li>
+          <li>Turn on <b>Developer mode</b> (top-right).</li>
+          <li>Click <b>Load unpacked</b> and pick the unzipped folder.</li>
+          <li>Open a TikTok Shop seller/order page — the tok-scrape button appears.</li>
+        </ol>
+        <p class="note">Chrome blocks <code>.crx</code> installs from outside the Web Store for normal profiles, so the supported path is the <b>.zip + Load unpacked</b> above (no <code>.crx</code> is published). Enterprise force-install is the only exception.</p>
+      </div>
+
+      <p class="muted">No extension? You can still run Samples-Import directly via the Claude browser skill (the <code>samples-import</code> skill) — it opens the page and drives it without the extension.</p>
+    </div>
+  </body>
+</html>

--- a/static/os.css
+++ b/static/os.css
@@ -134,6 +134,21 @@ button {
   white-space: nowrap;
 }
 
+.role-switch {
+  margin-left: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-dim);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.role-switch:hover { background: rgba(255, 255, 255, 0.1); }
+.role-switch:focus { outline: none; border-color: var(--gold); }
+
 .clock {
   color: var(--text-dim);
   font-weight: 600;

--- a/static/os.js
+++ b/static/os.js
@@ -198,6 +198,17 @@ const FOLDERS = [
         width: 1180,
         height: 780,
       },
+      {
+        id: "install-extension",
+        name: "Install Extension",
+        icon: ICONS.boxes,
+        // Same-origin install help: download chrome.zip + load-unpacked steps
+        // (served by data-pimp at /install). Internal, so no sandbox — the
+        // download link works. Opened by the samples-import skill or from Apps.
+        url: "/install",
+        width: 600,
+        height: 720,
+      },
     ],
   },
   {
@@ -1038,3 +1049,39 @@ document.body.insertAdjacentHTML("afterbegin", ICON_GRADIENTS);
 renderDesktop();
 tickClock();
 setInterval(tickClock, 15000);
+
+// Profile / role switcher. Per-device only (localStorage) — the OS has no
+// auth/session to hang a server-side role on. DJ = default; KA = warehouse Karl,
+// who boots straight into a tiled Inventory + Kiosk workspace.
+const ROLE_KEY = "thirsty-os-role";
+const role = localStorage.getItem(ROLE_KEY) || "dj";
+const roleSwitch = document.getElementById("role-switch");
+if (roleSwitch) {
+  roleSwitch.value = role;
+  roleSwitch.addEventListener("change", () => {
+    localStorage.setItem(ROLE_KEY, roleSwitch.value);
+    location.reload(); // re-run boot so the layout branch below applies cleanly
+  });
+}
+
+// Warehouse boot layout: Inventory (LP Sample Tracker) tiled to the LEFT half,
+// defaulting to the "Cleared to Sell" filter; Kiosk tiled to the RIGHT half.
+// Reuses the real openApp() + snapWindow() primitives (windows keyed "app:"+id).
+if (role === "ka") {
+  const appsFolder = FOLDERS.find((f) => f.id === "apps");
+  const apps = (appsFolder && appsFolder.items) || [];
+  const inventory = apps.find((i) => i.id === "inventory");
+  const kiosk = apps.find((i) => i.id === "kiosk");
+  if (inventory) {
+    // ?status=cleared_to_sell pre-selects the warehouse filter (the tracker reads it).
+    openApp({ ...inventory, url: inventory.url + "?status=cleared_to_sell" });
+    const w = windows.get("app:inventory");
+    if (w) snapWindow(w, "left");
+  }
+  if (kiosk) {
+    openApp(kiosk);
+    const w = windows.get("app:kiosk");
+    if (w) snapWindow(w, "right");
+  }
+  if (statusEl) statusEl.textContent = "Warehouse · Karl";
+}


### PR DESCRIPTION
## What

Warehouse role in Thirsty OS, the order-scrape → dropdown payoff, and the install/load skill.

### Warehouse role (DJ → KA)
- `static/os.js` + `main.ts` `renderOSShell()` + `static/os.css`: a **profile switcher** `<select>` in the taskbar (DJ / Karl · Warehouse). It persists `thirsty-os-role` in **localStorage** (the OS has no auth/session — per-device by design) and reloads. On boot as **KA**, the OS tiles **Inventory (LP Sample Tracker) to the left half** — opened with `?status=cleared_to_sell` so it defaults to the Cleared-to-Sell filter — and **Kiosk to the right half**, reusing the real `openApp()` + `snapWindow()` primitives.

### Order-scrape → assigned-creator dropdown
- `core/graylog.ts` `fetchOrderCreatorsByName(name)`: order-detail scrapes now carry `_creator` (display name) + `_default_product` (in tok-scrape#78), so this name-matches them. `/api/product-creators?...&name=<name>` returns them as `orderCreators` (display-name form, distinct from affiliate-export `orderedCreators`). **Honest:** order scrapes carry no numeric productId, so this is a fuzzy name match; a real id needs the main-world hook (flagged).

### Install / load
- `static/install.html` + `/install` route + an **Apps → Install Extension** OS app: download `chrome.zip` + load-unpacked steps + the `.crx`-blocked caveat. Same-origin so the OS window is unsandboxed and the download works.
- `.claude/skills/samples-import/SKILL.md`: open Samples-Import via the Claude-in-Chrome browser skill or the extension; surface install help in an OS window or browser tab.

## Verification
- `deno check` clean (0 TS errors); `node --check static/os.js` OK.

## Notes / honesty
- Role persistence is per-device localStorage (no server session exists).
- Order-scrape attribution is a display name + name-match (no numeric productId from the order DOM).
- "Cleared to Sell" is a default-selected filter (the tracker reads `?status=` — easierbycode/tiktok-sample-tracker#60), not a status-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
