### PR TITLE
Repeatable sample-lifecycle e2e: scripts/sample-e2e.ts + OS two-pane workspace + skill

### DIFF
--- a/.claude/skills/sample-e2e/SKILL.md
+++ b/.claude/skills/sample-e2e/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: sample-e2e
+description: >-
+  Run the repeatable sample-lifecycle end-to-end test, and/or open the visual
+  two-pane workspace. Trigger when the user wants to e2e-test the import/lifecycle
+  pipeline, "test these product ids", verify the API + Graylog path, or watch an
+  import happen visually. Feed an array of TikTok product IDs (priced and/or
+  unpriced); it walks hydrate → import (assign to creator) → Postgres verify →
+  Graylog/dropdown verify, and can also show it: Samples-Import replaying the adds
+  on the left, Apps/Inventory table on the right.
+allowed-tools: Bash, mcp__Claude_in_Chrome__list_connected_browsers, mcp__Claude_in_Chrome__navigate
+---
+
+# sample-e2e
+
+Two halves — a scriptable API+Graylog walk, and a visual two-pane workspace. Use
+either or both for whatever the user is verifying.
+
+## Part 1 — the repeatable test (script)
+
+`data-pimp/scripts/sample-e2e.ts` (also `deno task e2e:samples`). Feed product
+IDs; it walks, per id:
+1. **hydrate** `GET /api/product-lookup/:id` → reports PRICED vs unpriced
+2. **import** `POST /api/sample-import` → create row + assign to the creator
+3. **verify Postgres** `GET /api/samples?id=` → `status=checked_out`, `checked_out_to`
+4. **verify Graylog** — the import's `graylog:true` + the creator surfacing in `/api/creators`
+
+```bash
+# from the data-pimp repo:
+deno task e2e:samples --creator @e2e-test --cleanup 1729587769570529799 9001234567890
+# or with the order-scrape variant (needs GELF creds):
+deno run -A scripts/sample-e2e.ts --order-scrape \
+  --gelf-url https://tok-graylog-gelf.ngrok-free.dev/gelf --gelf-token <token> \
+  --cleanup <productId> ...
+```
+
+- No product ids → a default priced + unpriced pair, so both paths run out of the box.
+- **`--cleanup`** deletes every sample + transaction it created (use it for a CI-style run; omit to leave the rows for inspection in Inventory).
+- **`--order-scrape`** posts a synthetic order-detail GELF (display-name creator + `stableProductId`) and confirms it surfaces in `/api/product-creators` `orderCreators` — the order-scrape → dropdown payoff. Gated on `--gelf-url`/`--gelf-token` (or `GRAYLOG_GELF_URL`/`GRAYLOG_TOKEN` env) so no secret is committed.
+- Exit code is non-zero if any check fails. Report the pass/fail matrix verbatim.
+
+The order-detail **scraper transform** test (runs the real `scrape-order.js` against a fake order page) lives in tok-scrape: `extension-seller/test-order-scrape.mjs` (`deno run -A`).
+
+## Part 2 — the visual two-pane workspace
+
+Open Thirsty OS with `?workspace=samples-import` to watch it: **Samples-Import
+tiles LEFT and auto-replays the import** (each product shown in the order modal),
+**Apps/Inventory tiles RIGHT** as a table of the imported rows (edit / enhance via
+its "Fetch from API"). Pass the run's ids/creator straight through:
+
+```
+https://thirsty.store/?workspace=samples-import&autostart=1&creator=@e2e-test&ids=1729587769570529799,9001234567890
+```
+
+Via the Claude-in-Chrome browser skill: `list_connected_browsers` → `navigate` to
+that URL. (Without `autostart=1` it just prefills, so the user clicks Start.)
+
+## Typical flow
+
+1. Run Part 1 with the user's product ids (omit `--cleanup` so the rows persist).
+2. Open Part 2 with the same `ids`/`creator` so the user sees the adds land and
+   can inspect/edit them in the Inventory table.
+3. Offer `--cleanup` (or delete via Inventory) when done.
+
+## Guardrails
+- Runs against **production** (`thirsty.store`) by default — it creates real
+  sample rows. Use `--cleanup`, an obvious test `--creator` (e.g. `@e2e-test`),
+  and `--api` to point at a non-prod deployment when available.
+- Graylog is append-only: order-scrape test events persist (clearly tagged).
+- This skill verifies/visualizes; the actual writes are `sample-lifecycle` /
+  `/api/sample-import`. Product research is `scrapecreators-api`.

--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,7 @@
     "check": "deno check main.ts",
     "sync:statuses": "deno run --allow-net --allow-read --allow-write --allow-env scripts/sync-statuses.ts",
     "seed:kiosk": "deno run -A scripts/seed-from-kiosk.ts",
+    "e2e:samples": "deno run -A scripts/sample-e2e.ts",
     "member:build": "cd member && deno task build",
     "build": "deno task member:build",
     "build:mac": "deno task member:build && deno compile -A --include static --include member/_fresh --target aarch64-apple-darwin --output build/data-pimp-mac-arm64 main.ts && deno compile -A --include static --include member/_fresh --target x86_64-apple-darwin --output build/data-pimp-mac-x64 main.ts",

--- a/scripts/sample-e2e.ts
+++ b/scripts/sample-e2e.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env -S deno run -A
+// Repeatable sample-lifecycle E2E. Feed product IDs (priced and/or unpriced) and
+// it walks the full API + Graylog path against a live deployment:
+//
+//   per product id:
+//     1. hydrate         GET  /api/product-lookup/:id   -> {name, price, image}
+//     2. import          POST /api/sample-import         -> create row + assign to creator
+//     3. verify Postgres GET  /api/samples?id=<sampleId> -> status checked_out, checked_out_to
+//     4. verify Graylog  the import's graylog:true + the creator surfacing in /api/creators
+//
+// Optional --order-scrape (needs a GELF endpoint) also posts a synthetic
+// order-detail event and confirms the creator surfaces in /api/product-creators
+// (the order-scrape -> dropdown payoff).
+//
+// Usage:
+//   deno run -A scripts/sample-e2e.ts [flags] <productId> [<productId> ...]
+//   deno task e2e:samples 1729587769570529799 9001234567890
+//
+// Flags:
+//   --creator @handle     creator to assign to (default @e2e-test)
+//   --api URL             API base (default https://thirsty.store)
+//   --cleanup             delete every sample + transaction it created
+//   --order-scrape        also run the synthetic order-event -> dropdown check
+//   --gelf-url URL        GELF input (or env GRAYLOG_GELF_URL) for --order-scrape
+//   --gelf-token TOKEN    GELF key   (or env GRAYLOG_TOKEN)    for --order-scrape
+//
+// If no product ids are passed, a default pair is used: one likely-priced real
+// TikTok product + one synthetic name-hash id (an "unpriced" sample), so the run
+// exercises both the priced and unpriced paths out of the box.
+
+type Json = Record<string, unknown>;
+
+function parseArgs(argv: string[]) {
+  const o: Record<string, string | boolean> = {};
+  const ids: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) { o[key] = next; i++; } else o[key] = true;
+    } else ids.push(a);
+  }
+  return { o, ids };
+}
+
+const { o, ids: argIds } = parseArgs(Deno.args);
+const API = String(o.api || "https://thirsty.store").replace(/\/+$/, "");
+const CREATOR = String(o.creator || "@e2e-test");
+const CLEANUP = Boolean(o.cleanup);
+const ORDER_SCRAPE = Boolean(o["order-scrape"]);
+const GELF_URL = String(o["gelf-url"] || Deno.env.get("GRAYLOG_GELF_URL") || "");
+const GELF_TOKEN = String(o["gelf-token"] || Deno.env.get("GRAYLOG_TOKEN") || "");
+
+// "900"+FNV-1a(clean(name)) — matches data-pimp stableProductId + the scrapers.
+function stableProductId(name: string): string {
+  const s = name.replace(/\s+/g, " ").trim();
+  if (!s) return "";
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return "900" + String(h >>> 0).padStart(10, "0");
+}
+
+const ids = argIds.length
+  ? argIds
+  : ["1729587769570529799", stableProductId("E2E Unpriced Sample")];
+
+async function getJson(path: string): Promise<Json | Json[] | null> {
+  try {
+    const r = await fetch(`${API}${path}`, { headers: { accept: "application/json" } });
+    return r.ok ? await r.json() : null;
+  } catch { return null; }
+}
+async function postJson(path: string, body: Json): Promise<Json> {
+  try {
+    const r = await fetch(`${API}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return await r.json();
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  console.log(`    ${ok ? "✓" : "✗ FAIL"}  ${name}${detail ? ` — ${detail}` : ""}`);
+  ok ? pass++ : fail++;
+}
+
+const created: { sampleId: number }[] = [];
+
+console.log(`Sample E2E → ${API} · creator ${CREATOR} · ${ids.length} product id(s)\n`);
+
+for (const id of ids) {
+  console.log(`▶ product ${id}`);
+  // 1. hydrate
+  const hyd = await getJson(`/api/product-lookup/${encodeURIComponent(id)}`) as Json | null;
+  const priced = !!(hyd && Number(hyd.price) > 0);
+  const name = (hyd && (hyd.name as string)) || id;
+  console.log(`    hydrate: ${priced ? "PRICED" : "unpriced"} · ${name}${hyd && hyd.price ? ` · $${hyd.price}` : ""}`);
+
+  // 2. import (create row + assign to creator)
+  const imp = await postJson("/api/sample-import", {
+    productId: id,
+    name,
+    price: hyd ? hyd.price : 0,
+    image: hyd ? hyd.image : null,
+    seller: hyd ? hyd.seller : null,
+    creator: CREATOR,
+  });
+  check("import ok", imp.ok === true, String(imp.error || ""));
+  check("import wrote Graylog", imp.graylog === true);
+  const sampleId = Number((imp.sampleId as number) ?? NaN);
+  check("import created Postgres row", !!(imp.postgres as Json)?.created && Number.isFinite(sampleId));
+  if (Number.isFinite(sampleId)) created.push({ sampleId });
+
+  // 3. verify Postgres truth
+  if (Number.isFinite(sampleId)) {
+    const rows = await getJson(`/api/samples?id=${sampleId}`);
+    const row = (Array.isArray(rows) ? rows[0] : rows) as Json | undefined;
+    check("Postgres status=checked_out", row?.status === "checked_out", String(row?.status || "?"));
+    check("Postgres checked_out_to=creator", row?.checked_out_to === CREATOR, String(row?.checked_out_to || "?"));
+  }
+  console.log("");
+}
+
+// 4. verify Graylog: the creator surfaced from the assignment events
+console.log("▶ Graylog: creator surfaces in /api/creators");
+let seen = false;
+for (let i = 0; i < 6 && !seen; i++) {
+  await sleep(5000);
+  const j = await getJson(`/api/creators?limit=200`) as Json | null;
+  const list = (j?.creators as string[]) || [];
+  if (list.includes(CREATOR)) seen = true;
+}
+check(`creator "${CREATOR}" in /api/creators`, seen, seen ? "" : "not indexed in window");
+console.log("");
+
+// 5. optional order-scrape → dropdown
+if (ORDER_SCRAPE) {
+  console.log("▶ order-scrape variant (synthetic order event → /api/product-creators)");
+  if (!GELF_URL || !GELF_TOKEN) {
+    console.log("    (skipped — pass --gelf-url + --gelf-token or set GRAYLOG_GELF_URL/GRAYLOG_TOKEN)");
+  } else {
+    const oname = `E2E Order Product ${Date.now()}`;
+    const opid = stableProductId(oname);
+    const gelf: Json = {
+      version: "1.1",
+      host: "tiktok-bookmarklet-orders",
+      short_message: `e2e order: ${oname}`,
+      _order_id: "e2e" + Date.now(),
+      _store: "E2E Test Shop",
+      _default_product: oname,
+      _default_price: 19.99,
+      _creator: "E2E Order Tester",
+      _creator_kind: "display_name",
+      _product_id: opid,
+      _product_id_source: "name-hash",
+      _graylog_key: GELF_TOKEN,
+    };
+    let posted = false;
+    try {
+      const r = await fetch(GELF_URL.endsWith("/gelf") ? GELF_URL : `${GELF_URL}/gelf`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(gelf),
+      });
+      posted = r.ok;
+      check("order GELF accepted", r.ok, `HTTP ${r.status}`);
+    } catch (e) {
+      check("order GELF accepted", false, e instanceof Error ? e.message : String(e));
+    }
+    if (posted) {
+      let ok = false;
+      for (let i = 0; i < 6 && !ok; i++) {
+        await sleep(5000);
+        const j = await getJson(`/api/product-creators?productId=${opid}&name=${encodeURIComponent(oname)}`) as Json | null;
+        if (((j?.orderCreators as string[]) || []).includes("E2E Order Tester")) ok = true;
+      }
+      check("order creator in /api/product-creators orderCreators", ok);
+    }
+  }
+  console.log("");
+}
+
+// cleanup
+if (CLEANUP && created.length) {
+  console.log(`▶ cleanup: deleting ${created.length} sample(s) + transactions`);
+  for (const { sampleId } of created) {
+    const txns = await getJson(`/api/transactions?sample_id=${sampleId}`) as Json[] | null;
+    for (const t of (Array.isArray(txns) ? txns : [])) {
+      await fetch(`${API}/api/transactions/${t.id}`, { method: "DELETE" }).catch(() => {});
+    }
+    await fetch(`${API}/api/samples/${sampleId}`, { method: "DELETE" }).catch(() => {});
+  }
+  console.log("    done\n");
+} else if (created.length) {
+  console.log(`▶ left ${created.length} sample(s) in inventory (pass --cleanup to remove): ${created.map((c) => c.sampleId).join(", ")}\n`);
+}
+
+console.log(`Result: ${pass} passed, ${fail} failed.`);
+Deno.exit(fail ? 1 : 0);

--- a/static/os.js
+++ b/static/os.js
@@ -1085,3 +1085,32 @@ if (role === "ka") {
   }
   if (statusEl) statusEl.textContent = "Warehouse · Karl";
 }
+
+// E2E / demo workspace: ?workspace=samples-import[&ids=...&creator=@x&autostart=1]
+// tiles the Samples-Import app (LEFT, auto-replaying the run's product ids) and
+// Apps/Inventory (RIGHT, the imported rows in a table, editable/enhanceable via
+// "Fetch from API"). The visual half of the sample-e2e skill. Reuses openApp +
+// snapWindow; the ids/creator pass straight through to the import app's demo mode.
+const wsParams = new URLSearchParams(location.search);
+if (wsParams.get("workspace") === "samples-import") {
+  const apps = (FOLDERS.find((f) => f.id === "apps") || {}).items || [];
+  const demos = (FOLDERS.find((f) => f.id === "demos") || {}).items || [];
+  const importApp = demos.find((i) => i.id === "samples-import");
+  const inventory = apps.find((i) => i.id === "inventory");
+  if (importApp) {
+    const q = new URLSearchParams();
+    ["ids", "creator", "autostart", "api"].forEach((k) => {
+      if (wsParams.get(k)) q.set(k, wsParams.get(k));
+    });
+    const qs = q.toString();
+    openApp({ ...importApp, url: importApp.url + (qs ? "?" + qs : "") });
+    const w = windows.get("app:samples-import");
+    if (w) snapWindow(w, "left");
+  }
+  if (inventory) {
+    openApp(inventory);
+    const w = windows.get("app:inventory");
+    if (w) snapWindow(w, "right");
+  }
+  if (statusEl) statusEl.textContent = "Samples-Import · e2e";
+}


### PR DESCRIPTION
## What

The repeatable sample-lifecycle e2e — runnable by feeding product IDs, with a visual two-pane workspace.

### 1. `scripts/sample-e2e.ts` (+ `deno task e2e:samples`)
Feed product IDs (priced and/or unpriced); per id it walks the full API + Graylog path:
1. **hydrate** `GET /api/product-lookup/:id` → reports PRICED vs unpriced
2. **import** `POST /api/sample-import` → create row + assign to creator
3. **verify Postgres** `GET /api/samples?id=` → `status=checked_out`, `checked_out_to`
4. **verify Graylog** — the import's `graylog:true` + the creator surfacing in `/api/creators`

`--cleanup` deletes everything it created; `--order-scrape` (gated on GELF creds via flag/env, no secret committed) also posts a synthetic order event and confirms it in `/api/product-creators`. No ids → a default priced+unpriced pair. Non-zero exit on any failure.

Verified live: priced (Goli, $74.94) + unpriced synthetic id → 11/11 checks, then cleaned up.

### 2. OS two-pane workspace (`static/os.js`)
`?workspace=samples-import[&ids=…&creator=@x&autostart=1]` tiles **Samples-Import LEFT** (auto-replaying the run's adds) and **Apps/Inventory RIGHT** (imported rows in a table, editable/enhanceable via "Fetch from API"). Reuses `openApp`/`snapWindow`; ids/creator pass straight through to the import app's demo mode (tok-scrape #81).

### 3. `sample-e2e` skill
Documents running the script with product ids (API+Graylog walk) and opening the visual two-pane (via URL or Claude-in-Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
