### PR TITLE
Per-creator resale revenue: recordSampleSold graylogOnly mode + CORS + creator-from-history

### DIFF
--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -360,6 +360,93 @@ export async function fetchOrderCreatorsByName(
   }
 }
 
+// Resolve which creator a physical sample was assigned to, from its assignment
+// history (sample_assignment_json events emitted by recordSampleImport /
+// recordSampleAssignment, keyed by sample_id + product_id + creator). Used to
+// attribute resale revenue when the caller (the tracker dashboard) can't supply
+// a creator — checked_out_to is cleared on check-in, but the assignment event
+// is append-only. Prefers an exact sample_id match, then the most recent.
+export async function fetchAssignedCreatorForSample(
+  sampleId?: string | number,
+  productId?: string,
+): Promise<string | null> {
+  const config = graylogConfigFromEnv();
+  const sid = String(sampleId ?? "").trim();
+  const pid = String(productId ?? "").trim();
+  if (!config || (!sid && !pid)) return null;
+
+  const idClauses: string[] = [];
+  if (sid) idClauses.push(`sample_id:"${sid.replace(/"/g, '\\"')}"`);
+  if (pid) idClauses.push(`product_id:"${pid.replace(/"/g, '\\"')}"`);
+  const idClause = idClauses.length > 1
+    ? `(${idClauses.join(" OR ")})`
+    : idClauses[0];
+
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365 * 2,
+    };
+    const messages = await searchGraylog(
+      wide,
+      `creator:* AND sample_assignment_json:* AND ${idClause}`,
+      200,
+      ["timestamp", "creator", "sample_id", "product_id"],
+    );
+    let best: { creator: string; ts: string; sidMatch: boolean } | null = null;
+    for (const message of messages) {
+      const creator = typeof message.creator === "string"
+        ? message.creator.trim()
+        : "";
+      if (!creator) continue;
+      const ts = typeof message.timestamp === "string" ? message.timestamp : "";
+      const sidMatch = !!sid && String(message.sample_id ?? "") === sid;
+      // Prefer an exact sample_id match; among equals, the most recent timestamp.
+      if (
+        !best ||
+        (sidMatch && !best.sidMatch) ||
+        (sidMatch === best.sidMatch && ts > best.ts)
+      ) {
+        best = { creator, ts, sidMatch };
+      }
+    }
+    return best ? best.creator : null;
+  } catch {
+    return null;
+  }
+}
+
+// Has this sample already had a tracker-resale revenue event written? Used as an
+// idempotency backstop in recordSampleSold's graylogOnly mode, which skips the
+// double-sell guard (the caller owns Postgres state). GELF is append-only and
+// gmv_num is summed client-side, so a re-emit would double-count a creator's
+// resale GMV. On any error we return false (don't block — best-effort; the
+// caller's UI already gates re-fire).
+export async function hasResaleEventForSample(
+  sampleId?: string | number,
+): Promise<boolean> {
+  const config = graylogConfigFromEnv();
+  const sid = String(sampleId ?? "").trim();
+  if (!config || !sid) return false;
+  try {
+    const wide: GraylogConfig = {
+      ...config,
+      rangeSeconds: 60 * 60 * 24 * 365 * 2,
+    };
+    const messages = await searchGraylog(
+      wide,
+      `sample_sold_json:* AND sample_source:"tracker-resale" AND sample_id:"${
+        sid.replace(/"/g, '\\"')
+      }"`,
+      1,
+      ["timestamp", "sample_id"],
+    );
+    return messages.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 // Scheduled-listing intents (sample_schedule_json) paired with their fired
 // markers (sample_schedule_done_json), for the auto-list cron. 1-year window —
 // schedules are short-lived. Errors degrade to empty so the cron just no-ops.

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -21,7 +21,12 @@
 // `product_id` on Graylog events. `sample_id` is stamped alongside so the two
 // systems reconcile even when a qr_code holds a barcode instead of a real id.
 
-import { fetchScheduleRecords, sendGelfMessage } from "./graylog.ts";
+import {
+  fetchAssignedCreatorForSample,
+  fetchScheduleRecords,
+  hasResaleEventForSample,
+  sendGelfMessage,
+} from "./graylog.ts";
 import { Bundles, InventoryTransactions, Samples } from "../db.ts";
 import sampleStatuses from "./sample-statuses.json" with { type: "json" };
 import campaignConfig from "./campaign-config.json" with { type: "json" };
@@ -78,6 +83,12 @@ export type SoldInput = SampleRef & {
   // Re-sell an already-sold sample on purpose (re-attribution). Off by default
   // because the Graylog revenue total can't be un-inflated — see the guard.
   force?: boolean;
+  // Emit ONLY the per-creator Graylog revenue event — skip the Postgres update,
+  // the audit transaction, and the double-sell guard. For callers that already
+  // own the Postgres sale (the LP Sample Tracker dashboard) but want the resale
+  // revenue attributed per creator. Creator is resolved from assignment history
+  // when not supplied.
+  graylogOnly?: boolean;
   // Set by recordBulkSampleSold to tie a per-sample sale back to its bulk lot.
   bulkId?: string;
   bulkTotal?: number | string;
@@ -538,13 +549,7 @@ export async function recordSampleStatus(
 // and the analytics event to Graylog. `creator`, `salePrice`, and `marketplace`
 // are required; fees/shipping/costBasis are optional and feed the computed net.
 export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
-  const creator = String(input.creator || "").trim();
-  if (!creator) {
-    throw new Error(
-      "creator is required — which creator account should this resale revenue " +
-        "be attributed to?",
-    );
-  }
+  const graylogOnly = input.graylogOnly === true;
   const salePrice = toNumber(input.salePrice);
   if (!(salePrice > 0)) {
     throw new Error("salePrice must be a positive number");
@@ -561,17 +566,72 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
   const costBasis = numOrZero(input.costBasis);
   const net = round2(salePrice - fees - shipping - costBasis);
 
-  const row = await resolveSampleRow(input, { preferUnsold: true });
+  const row = await resolveSampleRow(input, { preferUnsold: !graylogOnly });
   const sampleId = row ? Number(row.id) : null;
   const productId = productIdOf(row, input);
   const name = row ? String(row.name ?? "").trim() || null : null;
   const previousStatus = row ? String(row.status ?? "").trim() || null : null;
 
+  // Creator is required for attribution. In graylogOnly mode the caller (the
+  // tracker dashboard) often can't supply one — checked_out_to is cleared on
+  // check-in — so resolve it from the sample's assignment history, then fall
+  // back to a still-present checked_out_to on the row.
+  let creator = String(input.creator || "").trim();
+  if (!creator && graylogOnly) {
+    creator =
+      (await fetchAssignedCreatorForSample(
+        sampleId ?? undefined,
+        productId ?? undefined,
+      )) ||
+      (row && row.checked_out_to
+        ? String(row.checked_out_to).trim()
+        : "");
+  }
+  if (!creator) {
+    throw new Error(
+      "creator is required — which creator account should this resale revenue " +
+        "be attributed to?",
+    );
+  }
+
+  // Idempotency backstop for graylogOnly: that mode skips the double-sell guard
+  // below (the caller owns Postgres state), so refuse to re-emit a resale event
+  // for a sample that already has one — GELF is append-only and gmv_num is summed
+  // client-side, so a re-emit would permanently double-count the creator's GMV.
+  // force:true re-attributes on purpose.
+  if (
+    graylogOnly && input.force !== true && sampleId != null &&
+    (await hasResaleEventForSample(sampleId))
+  ) {
+    return {
+      ok: true,
+      sampleId,
+      productId,
+      name,
+      creator,
+      marketplace,
+      salePrice,
+      fees,
+      shipping,
+      costBasis,
+      net,
+      postgres: {
+        updated: false,
+        transactionId: null,
+        reason: "graylogOnly: caller owns the sale",
+      },
+      graylog: false,
+      message:
+        `Resale revenue for sample ${sampleId} was already attributed — skipped ` +
+        "to avoid double-counting (pass force:true to re-attribute).",
+    };
+  }
+
   // Guard against double-selling. GELF revenue events are append-only and the
   // read side sums `gmv_num` client-side, so a second sale permanently inflates
   // the creator's attributed revenue — the Postgres overwrite self-heals, the
   // analytics total can't. Refuse unless the caller explicitly re-attributes.
-  if (previousStatus === "sold" && input.force !== true) {
+  if (!graylogOnly && previousStatus === "sold" && input.force !== true) {
     const soldAt = row ? String(row.sold_at ?? "").trim() : "";
     throw new Error(
       `Sample ${row?.id ?? productId ?? "?"} is already sold${
@@ -590,7 +650,11 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
   let updated = false;
   let transactionId: number | null = null;
   const reasons: string[] = [];
-  if (row) {
+  if (graylogOnly) {
+    // The caller owns the Postgres sale + audit transaction; we only emit the
+    // analytics event below. Nothing to write here.
+    reasons.push("graylogOnly: Postgres update + audit transaction skipped (caller owns the sale)");
+  } else if (row) {
     try {
       await Samples.update(String(row.id), {
         status: "sold",
@@ -665,7 +729,9 @@ export async function recordSampleSold(input: SoldInput): Promise<SoldResult> {
       product_id: productId ?? undefined,
       sample_id: sampleId != null ? String(sampleId) : undefined,
       sample_status: "sold",
-      sample_source: bulkId ? "skill-bulk-resale" : "skill-resale",
+      sample_source: graylogOnly
+        ? "tracker-resale"
+        : (bulkId ? "skill-bulk-resale" : "skill-resale"),
       bulk_id: bulkId || undefined,
       bulk_total_num: bulkTotal ?? undefined,
     },

--- a/main.ts
+++ b/main.ts
@@ -1399,15 +1399,18 @@ export async function legacyHandler(req: Request): Promise<Response> {
       }
 
       // Mark a sample sold and attribute the resale revenue to a creator.
+      // CORS: the LP Sample Tracker (admin.thirsty.store) POSTs here cross-origin
+      // in graylogOnly mode to attribute resale revenue per creator.
       if (pathname === "/api/sample-sold") {
+        if (req.method === "OPTIONS") return corsPreflight();
         if (req.method !== "POST") {
-          return json({ ok: false, error: "Method not allowed" }, 405);
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
         }
         try {
-          return json(await recordSampleSold(await readJsonBody(req)));
+          return corsJson(await recordSampleSold(await readJsonBody(req)));
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
-          return json({ ok: false, error: msg }, 400);
+          return corsJson({ ok: false, error: msg }, 400);
         }
       }
 


### PR DESCRIPTION
## What
Lets the LP Sample Tracker dashboard "Mark as Sold" attribute **per-creator resale revenue** in Graylog, without disturbing the tracker's own Postgres sale.

### `recordSampleSold` — new `graylogOnly` mode (`core/lifecycle.ts`)
When `graylogOnly:true`: skip the Postgres `Samples.update`, skip the duplicate `'sold'` audit transaction, and skip the double-sell guard (the caller owns those). Emit only the `sample_sold_json` revenue event, tagged `sample_source:"tracker-resale"`. **Backward compatible** — defaults false, so `recordBulkSampleSold`, the MCP `mark_sample_sold`, and the default `/api/sample-sold` path keep the full dual-write + guard + required-creator.

### Creator resolution from history (`core/graylog.ts`)
`fetchAssignedCreatorForSample(sampleId, productId)` resolves the credited creator from `sample_assignment_json` history when the caller can't supply one — the tracker clears `checked_out_to` on check-in, but the assignment event is append-only. Prefers an exact `sample_id` match, then the most recent. Degrades to `null` on error (a Graylog outage can't break the sale path).

### Idempotency backstop (`core/graylog.ts` + `lifecycle.ts`)
Because `graylogOnly` skips the double-sell guard, `hasResaleEventForSample` checks for an existing `tracker-resale` event for the sample before emitting; if found (and not `force`), it returns ok with an "already attributed" message instead of double-counting GMV.

### CORS on `/api/sample-sold` (`main.ts`)
Added `OPTIONS`→`corsPreflight` and switched `json`→`corsJson` so `admin.thirsty.store` can POST cross-origin (verified OPTIONS reaches this branch; the thin-client proxy only engages in `REMOTE_API` mode).

`deno check` clean. Adversarial review (backward-compat + cross-origin/double-count lenses): both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
