### PR TITLE
Demos/E2E: one-click full-screen lifecycle demo on latest-creator data

### DIFF
--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -447,6 +447,93 @@ export async function hasResaleEventForSample(
   }
 }
 
+// Context for the one-click E2E demo (Demos/E2E): the latest creator to post and
+// a few of their recent products, so the demo runs the lifecycle on real data.
+// Priority: latest order_list creator + their last 3 ordered product_ids →
+// latest resale (sold) creator + their sold product_ids → any known creator +
+// the default id → a static default. searchGraylog sorts timestamp Descending,
+// so index 0 is the most recent. Always returns something usable.
+export async function fetchE2EContext(
+  defaultId: string,
+): Promise<{ creator: string; ids: string[]; source: string }> {
+  const fallback = { creator: "@e2e-demo", ids: [defaultId], source: "default" };
+  const config = graylogConfigFromEnv();
+  if (!config) {
+    return { ...fallback, source: "default (graylog unconfigured)" };
+  }
+  const wide: GraylogConfig = {
+    ...config,
+    rangeSeconds: 60 * 60 * 24 * 365 * 2,
+  };
+
+  // The most recent up-to-3 distinct product_ids belonging to `creator`.
+  const recentIdsFor = (
+    messages: Record<string, unknown>[],
+    creator: string,
+  ): string[] => {
+    const ids: string[] = [];
+    for (const m of messages) {
+      if (String(m.creator ?? "").trim() !== creator) continue;
+      const pid = String(m.product_id ?? "").trim();
+      if (pid && !ids.includes(pid)) ids.push(pid);
+      if (ids.length >= 3) break;
+    }
+    return ids;
+  };
+
+  try {
+    // "Latest creator to post" = most recent order_list scrape.
+    const orders = await searchGraylog(
+      wide,
+      `source:tiktok-bookmarklet-orders AND creator:*`,
+      100,
+      ["timestamp", "creator", "product_id"],
+    );
+    if (orders.length) {
+      const creator = String(orders[0].creator ?? "").trim();
+      if (creator) {
+        const ids = recentIdsFor(orders, creator);
+        if (ids.length) {
+          return { creator, ids, source: "graylog: latest creator order_list items" };
+        }
+      }
+    }
+    // Fallback: latest resale (sold) creator + their sold items.
+    const sold = await searchGraylog(
+      wide,
+      `sample_sold_json:* AND creator:*`,
+      100,
+      ["timestamp", "creator", "product_id"],
+    );
+    if (sold.length) {
+      const creator = String(sold[0].creator ?? "").trim();
+      if (creator) {
+        const ids = recentIdsFor(sold, creator);
+        if (ids.length) {
+          return { creator, ids, source: "graylog: latest creator sold items" };
+        }
+        return {
+          creator,
+          ids: [defaultId],
+          source: "graylog: latest sold creator + default id",
+        };
+      }
+    }
+    // Fallback: any known creator + the default product.
+    const known = await fetchKnownCreators(1);
+    if (known.length) {
+      return {
+        creator: known[0],
+        ids: [defaultId],
+        source: "graylog: known creator + default id",
+      };
+    }
+  } catch {
+    return { ...fallback, source: "default (graylog error)" };
+  }
+  return fallback;
+}
+
 // Scheduled-listing intents (sample_schedule_json) paired with their fired
 // markers (sample_schedule_done_json), for the auto-list cron. 1-year window —
 // schedules are short-lived. Errors degrade to empty so the cron just no-ops.

--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,7 @@ import {
 import {
   envValue,
   fetchCreatorsForProduct,
+  fetchE2EContext,
   fetchKnownCreators,
   fetchOrderCreatorsByName,
   graylogConfigFromEnv,
@@ -790,6 +791,9 @@ export async function legacyHandler(req: Request): Promise<Response> {
   if (pathname === "/install" || pathname === "/install.html") {
     return await serveLocalFile("./static/install.html", "text/html; charset=utf-8");
   }
+  if (pathname === "/e2e" || pathname === "/e2e.html") {
+    return await serveLocalFile("./static/e2e.html", "text/html; charset=utf-8");
+  }
   if (pathname === "/ui.js") {
     return await serveLocalFile("./static/ui.js", "text/javascript; charset=utf-8");
   }
@@ -1343,6 +1347,15 @@ export async function legacyHandler(req: Request): Promise<Response> {
         const raw = Number(url.searchParams.get("limit"));
         const limit = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 1000;
         return json({ creators: await fetchKnownCreators(limit) });
+      }
+
+      // Context for the one-click E2E demo (Demos/E2E): the latest creator + a
+      // few of their recent products, or a default product. CORS — the /e2e
+      // page fetches it client-side. ?id=<productId> overrides the default.
+      if (pathname === "/api/e2e-context") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        const def = (url.searchParams.get("id") || "1731301163454206492").trim();
+        return corsJson(await fetchE2EContext(def));
       }
 
       // Creators who ordered a given product (the derived assigned-creator

--- a/static/e2e.html
+++ b/static/e2e.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>E2E · Sample Lifecycle Demo</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      display: flex; flex-direction: column;
+      font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0b0b0f; color: #e8e8ea;
+    }
+    header {
+      flex: 0 0 auto; display: flex; align-items: center; gap: 12px;
+      padding: 12px 16px; border-bottom: 1px solid #1f1f27; background: #111118;
+    }
+    .logo {
+      width: 34px; height: 34px; border-radius: 9px; flex: 0 0 auto;
+      display: grid; place-items: center; font-size: 18px;
+      background: linear-gradient(135deg, #ff7a18, #af002d 80%);
+    }
+    .title { font-weight: 600; font-size: 15px; }
+    .sub { color: #9a9aa6; font-size: 12px; }
+    .ctx {
+      margin-left: auto; display: flex; align-items: center; gap: 10px;
+      flex-wrap: wrap; justify-content: flex-end;
+    }
+    .chip {
+      font-size: 12px; padding: 4px 9px; border-radius: 999px;
+      background: #1a1a22; border: 1px solid #2a2a35; color: #cfcfd6;
+      white-space: nowrap;
+    }
+    .chip b { color: #ffb27a; font-weight: 600; }
+    button {
+      font: inherit; font-size: 13px; cursor: pointer; color: #0b0b0f;
+      background: linear-gradient(135deg, #ff9a3c, #ff7a18); border: 0;
+      padding: 7px 14px; border-radius: 8px; font-weight: 600;
+    }
+    button:active { transform: translateY(1px); }
+    .stage { flex: 1 1 auto; position: relative; background: #0b0b0f; }
+    iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+    .overlay {
+      position: absolute; inset: 0; display: grid; place-items: center;
+      background: #0b0b0f; color: #9a9aa6; gap: 10px; text-align: center; padding: 24px;
+    }
+    .overlay.hidden { display: none; }
+    .spinner {
+      width: 26px; height: 26px; border-radius: 50%;
+      border: 3px solid #2a2a35; border-top-color: #ff7a18;
+      animation: spin 0.8s linear infinite; margin: 0 auto;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    code { color: #ffb27a; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">▶</div>
+    <div>
+      <div class="title">E2E · Sample Lifecycle Demo</div>
+      <div class="sub">Resolves the latest creator's recent items (or a default product) and runs the import live.</div>
+    </div>
+    <div class="ctx">
+      <span class="chip" id="ctx-creator">creator: …</span>
+      <span class="chip" id="ctx-ids">items: …</span>
+      <span class="chip" id="ctx-source">source: …</span>
+      <button id="rerun" type="button">↻ Re-run</button>
+    </div>
+  </header>
+
+  <div class="stage">
+    <iframe id="demo" title="Samples-Import demo" allow="fullscreen"
+      referrerpolicy="strict-origin-when-cross-origin"></iframe>
+    <div class="overlay" id="overlay">
+      <div>
+        <div class="spinner"></div>
+        <div id="overlay-msg" style="margin-top:10px">Resolving latest creator + items from analytics…</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    "use strict";
+    // The Samples-Import demo lives on GH Pages; it reads ?ids/&creator/&autostart
+    // (and &api for the backend). It calls the live thirsty.store import API.
+    var IMPORT_BASE = "https://easierbycode.com/tok-scrape/samples-import/www/";
+    var API = location.origin; // served from thirsty.store → talk to the same backend
+    var esc = function (s) {
+      return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+        return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+      });
+    };
+
+    function setChips(ctx) {
+      document.getElementById("ctx-creator").innerHTML = "creator: <b>" + esc(ctx.creator) + "</b>";
+      document.getElementById("ctx-ids").innerHTML =
+        "items: <b>" + (ctx.ids ? ctx.ids.length : 0) + "</b> (" +
+        esc((ctx.ids || []).join(", ")) + ")";
+      document.getElementById("ctx-source").innerHTML = "source: <b>" + esc(ctx.source) + "</b>";
+    }
+
+    function runDemo(ctx) {
+      setChips(ctx);
+      var u = new URL(IMPORT_BASE);
+      u.searchParams.set("api", API);
+      u.searchParams.set("autostart", "1");
+      u.searchParams.set("creator", ctx.creator);
+      u.searchParams.set("ids", (ctx.ids || []).join(","));
+      var iframe = document.getElementById("demo");
+      var overlay = document.getElementById("overlay");
+      iframe.addEventListener("load", function () { overlay.classList.add("hidden"); }, { once: true });
+      // Safety net for cross-origin load events that don't fire.
+      setTimeout(function () { overlay.classList.add("hidden"); }, 6000);
+      iframe.src = u.toString();
+    }
+
+    function load() {
+      var overlay = document.getElementById("overlay");
+      var msg = document.getElementById("overlay-msg");
+      overlay.classList.remove("hidden");
+      msg.textContent = "Resolving latest creator + items from analytics…";
+      fetch(API + "/api/e2e-context")
+        .then(function (r) { return r.json(); })
+        .then(function (ctx) {
+          if (!ctx || !ctx.creator || !ctx.ids || !ctx.ids.length) {
+            ctx = { creator: "@e2e-demo", ids: ["1731301163454206492"], source: "default (client fallback)" };
+          }
+          runDemo(ctx);
+        })
+        .catch(function () {
+          runDemo({ creator: "@e2e-demo", ids: ["1731301163454206492"], source: "default (offline)" });
+        });
+    }
+
+    document.getElementById("rerun").addEventListener("click", function () {
+      // Re-resolve context (a newer creator may have posted) and reload the demo.
+      var iframe = document.getElementById("demo");
+      iframe.removeAttribute("src");
+      load();
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/static/os.js
+++ b/static/os.js
@@ -256,6 +256,20 @@ const FOLDERS = [
         height: 840,
       },
       {
+        id: "e2e",
+        name: "E2E",
+        icon: ICONS.content,
+        // One-click sample-lifecycle demo: /e2e resolves the latest creator's
+        // recent items (or a default product) from analytics, then runs the
+        // Samples-Import import live. Same-origin page (no sandbox), opened
+        // full-screen so the demo has room to breathe — still draggable/restorable.
+        url: "/e2e",
+        allow: "fullscreen",
+        maximized: true,
+        width: 1100,
+        height: 760,
+      },
+      {
         id: "content-by-sample",
         name: "Content by Sample",
         icon: ICONS.content,
@@ -880,6 +894,10 @@ function openApp(item) {
   iframe.addEventListener("load", hide);
   win.loaderTimer = setTimeout(hide, 8000); // safety net for cross-origin loads
   win.el.querySelector(".window-body").appendChild(iframe);
+
+  // Apps can request a full-screen window (e.g. the E2E demo). Still draggable:
+  // the title-bar zoom button / Ctrl+Alt+Down restores it to the floating rect.
+  if (item.maximized) toggleMax(win);
 
   flashStatus(`Opening ${item.name}`);
 }


### PR DESCRIPTION
## What
A one-click **Demos/E2E** app: click the icon → a draggable, **full-screen-by-default** window opens and runs the sample-lifecycle demo on real latest data.

### `fetchE2EContext` (`core/graylog.ts`)
Resolves `{creator, ids, source}`:
1. **Latest creator to post** — most recent `tiktok-bookmarklet-orders` scrape + that creator's last 3 distinct `product_id`s.
2. else **latest resale (sold) creator** + their sold `product_id`s.
3. else **any known creator** + the default product.
4. else `@e2e-demo` + default.
Default product id `1731301163454206492` (override via `?id=`). `searchGraylog` sorts `timestamp Descending`, so index 0 is the latest; degrades gracefully so it always returns something usable.

### Routes (`main.ts`)
- `GET /api/e2e-context` (CORS) → the resolved context.
- `GET /e2e` → the demo page.

### `/e2e` page (`static/e2e.html`)
Full-viewport: a header with the resolved **creator / items / source** chips + a **Re-run** button, and the **Samples-Import** demo embedded (`?ids&creator&autostart&api`) so it imports those items live with the order-modal animation.

### OS (`static/os.js`)
New **E2E** item in the Demos folder (`url:/e2e`, `maximized:true`). `openApp` now honors `item.maximized` → opens the window full-screen via `toggleMax` (still draggable; zoom button / Ctrl+Alt+Down restores).

`deno check` + `node --check os.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
