### PR TITLE
E2E demo: dry-run by default (recordSampleImport dryRun + toggle)

### DIFF
--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -242,6 +242,10 @@ export type ImportInput = {
   autoListAfterDays?: number | string;
   marketplace?: string;
   askPrice?: number | string;
+  // Preview only: compute campaign match + enrichment + the would-be schedule,
+  // but write NOTHING (no Postgres row, no audit transaction, no Graylog event).
+  // Used by the E2E demo so it can show the lifecycle without polluting inventory.
+  dryRun?: boolean;
 };
 
 export type ScheduledListing = {
@@ -262,6 +266,7 @@ export type ImportResult = {
   scheduledListing: ScheduledListing | null;
   postgres: { created: boolean; transactionId: number | null; reason?: string };
   graylog: boolean;
+  dryRun?: boolean;
   message: string;
 };
 
@@ -1306,6 +1311,7 @@ export async function recordSampleImport(
   }
   const productId = String(input.productId ?? input.qrCode ?? "").trim();
   if (!productId) throw new Error("productId is required");
+  const dryRun = input.dryRun === true;
 
   const now = new Date().toISOString();
   const name = String(input.name || "").trim() || productId;
@@ -1334,15 +1340,19 @@ export async function recordSampleImport(
   let bundleRow: SampleRow | null = null;
   let transactionId: number | null = null;
   const reasons: string[] = [];
-  try {
-    const row = await Samples.create(createData) as SampleRow | undefined;
-    if (row?.id != null) {
-      sampleId = Number(row.id);
-      created = true;
-      bundleRow = row;
+  if (dryRun) {
+    reasons.push("dry-run: nothing written");
+  } else {
+    try {
+      const row = await Samples.create(createData) as SampleRow | undefined;
+      if (row?.id != null) {
+        sampleId = Number(row.id);
+        created = true;
+        bundleRow = row;
+      }
+    } catch (error) {
+      reasons.push(error instanceof Error ? error.message : String(error));
     }
-  } catch (error) {
-    reasons.push(error instanceof Error ? error.message : String(error));
   }
 
   const campaignEntry = matchCampaign(productId, name);
@@ -1353,13 +1363,13 @@ export async function recordSampleImport(
   // Optional auto-listing schedule (stub — records intent for the cron).
   let scheduledListing: ScheduledListing | null = null;
   const days = numOrZero(input.autoListAfterDays);
-  if (created && days > 0) {
+  if ((created || dryRun) && days > 0) {
     const marketplace = String(input.marketplace || "ebay").trim() || "ebay";
     const askNum = numOrZero(input.askPrice);
     const askPrice = askNum > 0 ? askNum : (price > 0 ? round2(price) : 0);
     const listAt = new Date(Date.now() + days * 86_400_000).toISOString();
     const scheduleId = `sched-${crypto.randomUUID()}`;
-    const ok = await sendGelfMessage(
+    const ok = dryRun ? true : await sendGelfMessage(
       `thirsty sample listing scheduled: ${name} → ${marketplace} in ${days}d`,
       {
         sample_schedule_json: JSON.stringify({
@@ -1412,7 +1422,7 @@ export async function recordSampleImport(
     }
   }
 
-  const graylog = await sendGelfMessage(
+  const graylog = dryRun ? false : await sendGelfMessage(
     `thirsty sample imported: ${name} → ${creator}`,
     {
       sample_assignment_json: JSON.stringify({
@@ -1455,7 +1465,7 @@ export async function recordSampleImport(
   const warn = warnings.length ? ` WARNING: ${warnings.join("; ")}.` : "";
 
   return {
-    ok: created || graylog,
+    ok: dryRun || created || graylog,
     sampleId,
     productId,
     name,
@@ -1469,11 +1479,16 @@ export async function recordSampleImport(
       reason: reasons.length ? reasons.join("; ") : undefined,
     },
     graylog,
-    message: `Imported ${name} → assigned to ${creator}${
-      campaign ? `, campaign "${campaign}"` : ""
-    } (persisted to ${where}).${warn}${
-      enrichment.length ? " " + enrichment.join(" ") : ""
-    }`,
+    dryRun: dryRun || undefined,
+    message: dryRun
+      ? `DRY-RUN — would import ${name} → assign to ${creator}${
+        campaign ? `, campaign "${campaign}"` : ""
+      } (nothing written).${enrichment.length ? " " + enrichment.join(" ") : ""}`
+      : `Imported ${name} → assigned to ${creator}${
+        campaign ? `, campaign "${campaign}"` : ""
+      } (persisted to ${where}).${warn}${
+        enrichment.length ? " " + enrichment.join(" ") : ""
+      }`,
   };
 }
 

--- a/static/e2e.html
+++ b/static/e2e.html
@@ -40,6 +40,12 @@
       padding: 7px 14px; border-radius: 8px; font-weight: 600;
     }
     button:active { transform: translateY(1px); }
+    .toggle {
+      display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+      font-size: 12px; padding: 4px 10px; border-radius: 999px;
+      background: #1a1a22; border: 1px solid #2a2a35; color: #cfcfd6; user-select: none;
+    }
+    .toggle input { accent-color: #ff7a18; margin: 0; }
     .stage { flex: 1 1 auto; position: relative; background: #0b0b0f; }
     iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
     .overlay {
@@ -67,6 +73,9 @@
       <span class="chip" id="ctx-creator">creator: …</span>
       <span class="chip" id="ctx-ids">items: …</span>
       <span class="chip" id="ctx-source">source: …</span>
+      <label class="toggle" title="Dry-run computes the campaign/enrichment and shows the flow, but writes no inventory.">
+        <input type="checkbox" id="dry" checked /> Dry-run
+      </label>
       <button id="rerun" type="button">↻ Re-run</button>
     </div>
   </header>
@@ -109,6 +118,8 @@
       u.searchParams.set("autostart", "1");
       u.searchParams.set("creator", ctx.creator);
       u.searchParams.set("ids", (ctx.ids || []).join(","));
+      // Default: dry-run (no inventory written). Uncheck to run a real import.
+      if (document.getElementById("dry").checked) u.searchParams.set("dryrun", "1");
       var iframe = document.getElementById("demo");
       var overlay = document.getElementById("overlay");
       iframe.addEventListener("load", function () { overlay.classList.add("hidden"); }, { once: true });
@@ -137,6 +148,13 @@
 
     document.getElementById("rerun").addEventListener("click", function () {
       // Re-resolve context (a newer creator may have posted) and reload the demo.
+      var iframe = document.getElementById("demo");
+      iframe.removeAttribute("src");
+      load();
+    });
+
+    // Toggling Dry-run/Live re-runs in the chosen mode (Live writes inventory).
+    document.getElementById("dry").addEventListener("change", function () {
       var iframe = document.getElementById("demo");
       iframe.removeAttribute("src");
       load();


### PR DESCRIPTION
## What
Makes the Demos/E2E demo **non-destructive by default** via a dry-run mode.

### `recordSampleImport` dry-run (`core/lifecycle.ts`)
`ImportInput.dryRun` / `ImportResult.dryRun`. When `dryRun:true`: skip `Samples.create`, the `check_out` audit transaction, the schedule GELF, and the assignment GELF — but still compute the campaign match, enrichment, and the would-be schedule. Returns `ok:true, created:false, graylog:false, dryRun:true` with a `DRY-RUN — would import …` message. Backward compatible (defaults off; real imports unchanged). `/api/sample-import` already has CORS, so the body flows through.

### E2E page (`static/e2e.html`)
A **Dry-run / Live** toggle in the header, **defaulting to Dry-run** — passes `dryrun=1` to the embedded Samples-Import so the demo shows the full lifecycle (resolve latest creator → hydrate → order-modal → "import") **without writing inventory**. Unchecking it re-runs as a real import.

`deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
