### PR TITLE
E2E demo: scripted lifecycle showcase (order list → tally → kiosk → cleared-to-sell → eBay → sold → Price-Is-Right reveal)

### DIFF
--- a/static/e2e.html
+++ b/static/e2e.html
@@ -3,217 +3,456 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>E2E · Sample Lifecycle Demo</title>
+  <title>E2E · Sample Lifecycle Showcase</title>
   <style>
-    :root { color-scheme: dark; }
+    :root {
+      color-scheme: dark;
+      --bg: #070a12; --card: #11151f; --border: #1d2433; --fg: #eef1f6; --muted: #9aa6bd;
+      --orange: #fb923c; --green: #22c55e; --sky: #38bdf8; --gold: #ffe27a;
+    }
     * { box-sizing: border-box; }
     html, body { height: 100%; margin: 0; }
     body {
-      position: relative; overflow: hidden;
-      font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      background: #0b0b0f; color: #e8e8ea;
+      overflow: hidden; position: relative; cursor: none;
+      font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(120% 120% at 80% -10%, #131a2b, var(--bg) 60%); color: var(--fg);
     }
 
-    /* The demo fills the whole window; the controls bar overlays the top only
-       when revealed (hidden by default so the demo is unobstructed). */
-    .stage { position: absolute; inset: 0; background: #0b0b0f; }
-    iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+    /* ---- top bar: running tally ---- */
+    .topbar {
+      position: absolute; top: 0; left: 0; right: 0; height: 56px; z-index: 5;
+      display: flex; align-items: center; gap: 14px; padding: 0 18px;
+      border-bottom: 1px solid var(--border); background: #0c111b;
+    }
+    .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand .dot { width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center;
+      background: linear-gradient(135deg, #ff7a18, #af002d 85%); font-size: 15px; }
+    .tally { margin-left: auto; display: flex; align-items: baseline; gap: 8px; }
+    .tally .lbl { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .06em; }
+    .tally .amt { font-weight: 800; font-size: 22px; color: var(--gold); font-variant-numeric: tabular-nums; }
+    .creator { color: var(--muted); font-size: 12px; }
+    .creator b { color: var(--fg); }
 
-    .bar {
-      position: absolute; top: 0; left: 0; right: 0; z-index: 20;
-      display: flex; align-items: center; gap: 12px;
-      padding: 12px 64px 12px 16px; /* right room for the info toggle */
-      border-bottom: 1px solid #1f1f27; background: #111118ee;
-      backdrop-filter: blur(6px); box-shadow: 0 8px 24px #0008;
-      transform: translateY(-110%); opacity: 0; pointer-events: none;
-      transition: transform .25s ease, opacity .25s ease;
-    }
-    .bar.shown { transform: translateY(0); opacity: 1; pointer-events: auto; }
+    /* ---- two-pane stage ---- */
+    .stage { position: absolute; top: 56px; left: 0; right: 0; bottom: 0; display: flex; }
+    .pane { flex: 1 1 0; min-width: 0; padding: 16px 18px; overflow: hidden; }
+    .pane.left { border-right: 1px solid var(--border); background: #0a0e16; }
+    .pane h2 { margin: 2px 0 12px; font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); font-weight: 700; }
+    .pane h2 .badge { color: var(--orange); }
 
-    .logo {
-      width: 34px; height: 34px; border-radius: 9px; flex: 0 0 auto;
-      display: grid; place-items: center; font-size: 18px;
-      background: linear-gradient(135deg, #ff7a18, #af002d 80%);
+    /* ---- order list (left) ---- */
+    .order {
+      display: flex; align-items: center; gap: 12px; padding: 10px 12px; margin-bottom: 8px;
+      background: var(--card); border: 1px solid var(--border); border-radius: 11px;
+      opacity: 0; transform: translateX(-14px); transition: opacity .3s ease, transform .3s ease, border-color .2s, background .2s;
     }
-    .title { font-weight: 600; font-size: 15px; }
-    .sub { color: #9a9aa6; font-size: 12px; }
-    .ctx {
-      margin-left: auto; display: flex; align-items: center; gap: 10px;
-      flex-wrap: wrap; justify-content: flex-end;
-    }
-    .chip {
-      font-size: 12px; padding: 4px 9px; border-radius: 999px;
-      background: #1a1a22; border: 1px solid #2a2a35; color: #cfcfd6;
-      white-space: nowrap;
-    }
-    .chip b { color: #ffb27a; font-weight: 600; }
-    button {
-      font: inherit; font-size: 13px; cursor: pointer; color: #0b0b0f;
-      background: linear-gradient(135deg, #ff9a3c, #ff7a18); border: 0;
-      padding: 7px 14px; border-radius: 8px; font-weight: 600;
-    }
-    button:active { transform: translateY(1px); }
-    .toggle {
-      display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
-      font-size: 12px; padding: 4px 10px; border-radius: 999px;
-      background: #1a1a22; border: 1px solid #2a2a35; color: #cfcfd6; user-select: none;
-    }
-    .toggle input { accent-color: #ff7a18; margin: 0; }
+    .order.in { opacity: 1; transform: none; }
+    .order.clicked { border-color: #2f6b3f; background: #102016; }
+    .thumb { width: 44px; height: 44px; border-radius: 9px; flex: 0 0 auto; display: grid; place-items: center; font-size: 22px; }
+    .order .meta { min-width: 0; flex: 1 1 auto; }
+    .order .nm { font-weight: 600; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .order .br { color: var(--muted); font-size: 12px; }
+    .order .vals { text-align: right; flex: 0 0 auto; }
+    .order .paid { color: var(--muted); font-size: 11px; }
+    .order .retail { font-weight: 700; color: var(--gold); font-size: 14px; }
+    .order .check { width: 20px; height: 20px; border-radius: 50%; border: 2px solid #39425a; flex: 0 0 auto;
+      display: grid; place-items: center; color: #0a0e16; font-size: 12px; transition: background .2s, border-color .2s; }
+    .order.clicked .check { background: var(--green); border-color: var(--green); }
 
-    /* Floating info toggle — always visible, reveals/hides the controls bar. */
-    .infobtn {
-      position: absolute; top: 12px; right: 14px; z-index: 30;
-      width: 34px; height: 34px; padding: 0; border-radius: 50%;
-      display: grid; place-items: center; font-size: 17px; font-weight: 700;
-      font-style: italic; line-height: 1; cursor: pointer;
-      color: #cfcfd6; background: #1a1a22cc; border: 1px solid #2a2a35;
-      backdrop-filter: blur(4px); box-shadow: 0 2px 8px #0006;
-      transition: background .2s ease, color .2s ease;
+    /* ---- kiosk grid (right) ---- */
+    .kiosk-head { display: flex; align-items: baseline; gap: 10px; margin: 2px 0 12px; }
+    .kiosk-head h1 { font-size: 18px; font-weight: 800; margin: 0; }
+    .kiosk-head .sub { color: var(--muted); font-size: 12px; }
+    .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    .kcard {
+      background: var(--card); border: 1px solid var(--border); border-radius: 12px; overflow: hidden;
+      opacity: 0; transform: translateY(12px) scale(.97); transition: opacity .4s ease, transform .4s cubic-bezier(.2,.9,.3,1.2), box-shadow .2s;
     }
-    .infobtn:hover { border-color: #3a3a48; }
-    .infobtn.is-open { background: linear-gradient(135deg, #ff9a3c, #ff7a18); color: #0b0b0f; }
-    /* Gentle pulse so the toggle is noticeable before the bar is first revealed. */
-    .infobtn.hint { animation: pulse 1.6s ease-in-out 3; }
-    @keyframes pulse {
-      0%, 100% { box-shadow: 0 2px 8px #0006; }
-      50% { box-shadow: 0 0 0 6px #ff7a1833; }
+    .kcard.in { opacity: 1; transform: none; }
+    .kcard.hero.focus { box-shadow: 0 0 0 2px var(--orange), 0 12px 30px #0008; }
+    .kcard .img { aspect-ratio: 1/1; display: grid; place-items: center; font-size: 40px; position: relative; }
+    .kcard .body { padding: 9px 11px 11px; }
+    .kcard .nm { font-weight: 600; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .kcard .br { color: var(--muted); font-size: 11px; }
+    .kcard .pr { font-weight: 800; margin-top: 5px; font-size: 13px; }
+    .kcard .pr .sold { color: var(--sky); font-weight: 600; font-size: 11px; }
+    .sbadge {
+      position: absolute; top: 8px; left: 8px; display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 9px; border-radius: 999px; font-size: 10.5px; font-weight: 700;
+      border: 1px solid; backdrop-filter: blur(2px); background: rgb(11 13 17 / 72%);
+      transition: color .25s, border-color .25s;
     }
+    .sbadge.available, .sbadge.cleared { color: var(--green); border-color: #2f7d4f; }
+    .sbadge.sold { color: var(--sky); border-color: #246c8a; }
+    .draftbtn {
+      position: absolute; bottom: 8px; right: 8px; font-size: 10.5px; font-weight: 700; padding: 3px 9px;
+      border-radius: 999px; border: 1px solid var(--orange); color: var(--orange); background: rgb(11 13 17 / 72%);
+      opacity: 0; transition: opacity .25s;
+    }
+    .kcard.cleared .draftbtn { opacity: 1; }
 
-    .overlay {
-      position: absolute; inset: 0; z-index: 10; display: grid; place-items: center;
-      background: #0b0b0f; color: #9a9aa6; gap: 10px; text-align: center; padding: 24px;
-    }
-    .overlay.hidden { display: none; }
-    .spinner {
-      width: 26px; height: 26px; border-radius: 50%;
-      border: 3px solid #2a2a35; border-top-color: #ff7a18;
-      animation: spin 0.8s linear infinite; margin: 0 auto;
-    }
+    .kiosk-loading { display: grid; place-items: center; height: 70%; color: var(--muted); gap: 12px; }
+    .spinner { width: 30px; height: 30px; border-radius: 50%; border: 3px solid #222b3d; border-top-color: var(--orange); animation: spin .8s linear infinite; }
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ---- fake cursor ---- */
+    .cursor { position: fixed; z-index: 9999; left: 0; top: 0; width: 22px; height: 22px; pointer-events: none;
+      transition: transform .7s cubic-bezier(.4,.1,.2,1); will-change: transform; filter: drop-shadow(0 2px 3px #000a); }
+    .cursor.fast { transition-duration: .45s; }
+    .ring { position: fixed; z-index: 9998; width: 14px; height: 14px; border-radius: 50%; pointer-events: none;
+      border: 2px solid var(--orange); opacity: 0; transform: translate(-50%, -50%); }
+    .ring.go { animation: ring .5s ease-out; }
+    @keyframes ring { 0% { opacity: .9; width: 8px; height: 8px; } 100% { opacity: 0; width: 46px; height: 46px; } }
+
+    /* ---- eBay draft overlay (lifted from ebay-draft.js) ---- */
+    .ebay-ov { position: fixed; inset: 0; z-index: 8000; display: none; place-items: center; padding: 24px;
+      background: rgba(6,8,12,.62); backdrop-filter: blur(2px); }
+    .ebay-ov.show { display: grid; animation: fade .2s ease; }
+    @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+    .ebd { width: min(520px, 94vw); max-height: 90vh; overflow: auto; background: #fff; color: #111;
+      border-radius: 14px; box-shadow: 0 40px 90px -30px rgba(0,0,0,.7); font: 14px/1.4 system-ui, sans-serif; }
+    .ebd-top { position: sticky; top: 0; background: #fff; border-bottom: 1px solid #e5e7eb; padding: 13px 16px;
+      display: flex; align-items: center; gap: 10px; }
+    .ebd-logo { font-weight: 700; font-size: 21px; letter-spacing: -.5px; }
+    .ebd-logo .e { color: #e53238; } .ebd-logo .b { color: #0064d2; } .ebd-logo .a { color: #f5af02; } .ebd-logo .y { color: #86b817; }
+    .ebd-h { color: #555; font-size: 15px; } .ebd-x { margin-left: auto; width: 28px; height: 28px; border-radius: 50%;
+      background: #f3f4f6; color: #444; display: grid; place-items: center; }
+    .ebd-banner { margin: 12px 16px 0; background: #fff3e6; border: 1px solid #f3c08a; color: #b3560a; font-size: 12.5px; padding: 8px 11px; border-radius: 8px; }
+    .ebd-body { padding: 14px 16px; display: flex; flex-direction: column; gap: 14px; }
+    .ebd-fld { position: relative; }
+    .ebd-fld > label { display: block; font-size: 12px; color: #6b7280; font-weight: 600; margin-bottom: 4px; }
+    .ebd-box { border: 1px solid #d1d5db; border-radius: 8px; padding: 10px 12px; font-size: 14px; transition: box-shadow .2s, border-color .2s; }
+    .ebd-box.flash { border-color: #f5af02; box-shadow: 0 0 0 3px #f5af0233; }
+    .ebd-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .ebd-pill { display: inline-block; background: #e7f5e9; color: #1b7a2e; border-radius: 999px; padding: 4px 12px; font-weight: 600; }
+    .ebd-ph { width: 60px; height: 60px; border-radius: 8px; display: inline-grid; place-items: center; font-size: 30px; background: #f1f3f5; }
+    .ebd-chip { position: absolute; top: -9px; right: 8px; background: #fff3e6; color: #b3560a; border: 1px solid #f3c08a;
+      font-size: 11px; font-weight: 600; padding: 2px 9px; border-radius: 99px; animation: ebpulse 1.8s ease-in-out infinite; }
+    @keyframes ebpulse { 0%, 100% { opacity: .55; } 50% { opacity: 1; } }
+    .ebd-foot { position: sticky; bottom: 0; background: #fff; border-top: 1px solid #e5e7eb; padding: 12px 16px;
+      display: flex; align-items: center; justify-content: space-between; }
+    .ebd-meta { color: #9aa3af; font-size: 12px; }
+    .ebd-open { background: #0064d2; color: #fff; border: 0; font-size: 14px; font-weight: 600; padding: 9px 18px; border-radius: 99px; }
+    .ebd-open.flash { box-shadow: 0 0 0 4px #0064d233; }
+
+    /* ---- mark-as-sold dialog (lifted from SellDialog) ---- */
+    .sold-ov { position: fixed; inset: 0; z-index: 8000; display: none; place-items: center; padding: 24px;
+      background: rgba(6,8,12,.62); backdrop-filter: blur(2px); }
+    .sold-ov.show { display: grid; animation: fade .2s ease; }
+    .sold-dlg { width: min(420px, 94vw); background: #11151f; border: 1px solid var(--border); border-radius: 14px; padding: 18px; }
+    .sold-dlg h3 { margin: 0 0 14px; display: flex; align-items: center; gap: 8px; font-size: 16px; }
+    .sold-dlg h3 .tag { color: var(--sky); }
+    .sold-card { background: #0c111b; border: 1px solid var(--border); border-radius: 9px; padding: 10px 12px; margin-bottom: 12px; }
+    .sold-card .nm { font-weight: 600; } .sold-card .br { color: var(--muted); font-size: 12px; }
+    .sold-fld { margin-bottom: 10px; } .sold-fld label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+    .sold-fld .inp { background: #0c111b; border: 1px solid var(--border); border-radius: 8px; padding: 9px 11px; font-size: 13px; }
+    .sold-btn { width: 100%; background: var(--sky); color: #06121a; border: 0; font-weight: 700; padding: 10px; border-radius: 9px; font-size: 14px; }
+
+    /* ---- Price-Is-Right showcase finale (lifted from samples-modal) ---- */
+    .showcase { position: fixed; inset: 0; z-index: 8500; display: none; flex-direction: column;
+      background: linear-gradient(160deg, #3a1066, #5a1e9c 55%, #1c0940);
+      align-items: center; justify-content: center; padding: 40px 20px; overflow: auto; }
+    .showcase.show { display: flex; animation: fade .35s ease; }
+    .bulbs { position: absolute; left: 0; right: 0; height: 14px; background-image: radial-gradient(circle, #ffe27a 0 3px, transparent 4px);
+      background-size: 26px 14px; opacity: .85; animation: chase 1s steps(2) infinite; }
+    .bulbs.top { top: 14px; } .bulbs.bot { bottom: 14px; }
+    @keyframes chase { to { background-position: 26px 0; } }
+    .sc-title { font-family: Georgia, "Times New Roman", serif; font-weight: 700; font-size: 26px; color: var(--gold);
+      text-shadow: 0 2px 0 #7a3c00, 0 0 18px rgba(255,210,80,.5); margin-bottom: 4px; text-align: center; }
+    .sc-sub { color: #d9c7ff; font-size: 13px; margin-bottom: 22px; }
+    .sc-lots { width: min(540px, 94vw); display: flex; flex-direction: column; gap: 12px; }
+    .sc-lot { display: flex; align-items: center; gap: 14px; padding: 14px 18px; border-radius: 12px;
+      background: rgba(255,255,255,.07); border: 1px solid rgba(255,226,122,.25);
+      opacity: 0; transform: translateY(12px) scale(.98); transition: opacity .4s ease, transform .4s cubic-bezier(.2,.9,.3,1.3); }
+    .sc-lot.in { opacity: 1; transform: none; }
+    .sc-lot .ico { font-size: 30px; } .sc-lot .t { flex: 1 1 auto; } .sc-lot .t .h { font-weight: 700; font-size: 15px; }
+    .sc-lot .t .d { color: #cdbcf0; font-size: 12px; }
+    .sc-lot .v { font-weight: 800; font-size: 22px; font-variant-numeric: tabular-nums; }
+    .sc-lot.value .v { color: var(--gold); } .sc-lot.profit .v { color: #aeffa0; }
+    .sc-final { width: min(540px, 94vw); margin-top: 18px; text-align: center; padding: 22px;
+      border-radius: 16px; border: 1px solid rgba(255,226,122,.4);
+      background: radial-gradient(120% 120% at 50% 0%, rgba(255,226,122,.22), rgba(255,226,122,0));
+      opacity: 0; transform: scale(.9); transition: opacity .45s ease, transform .45s cubic-bezier(.2,.9,.3,1.4); }
+    .sc-final.in { opacity: 1; transform: none; }
+    .sc-final .lab { letter-spacing: .18em; text-transform: uppercase; color: #e7d6ff; font-size: 12px; }
+    .sc-final .amt { font-family: Georgia, serif; font-weight: 800; font-size: 46px; color: var(--gold);
+      text-shadow: 0 2px 0 #7a3c00, 0 0 24px rgba(255,210,80,.6); margin: 4px 0; font-variant-numeric: tabular-nums; }
+    .sc-final .kick { color: #d9c7ff; font-size: 13px; } .sc-final .kick b { color: #aeffa0; }
+
+    .replay { position: fixed; z-index: 8600; bottom: 26px; left: 50%; transform: translateX(-50%);
+      background: linear-gradient(135deg, #ff9a3c, #ff7a18); color: #0b0b0f; border: 0; font-weight: 700;
+      font-size: 14px; padding: 10px 22px; border-radius: 999px; display: none; cursor: pointer; }
+    .replay.show { display: block; }
+
+    @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
   </style>
 </head>
 <body>
+  <div class="topbar">
+    <div class="brand"><span class="dot">▶</span> E2E · Sample Lifecycle</div>
+    <span class="creator" id="creator">creator <b>@sample_squad</b></span>
+    <div class="tally"><span class="lbl">Sample value</span><span class="amt" id="tally">$0.00</span></div>
+  </div>
+
   <div class="stage">
-    <iframe id="demo" title="Samples-Import demo" allow="fullscreen"
-      referrerpolicy="strict-origin-when-cross-origin"></iframe>
-    <div class="overlay" id="overlay">
-      <div>
-        <div class="spinner"></div>
-        <div id="overlay-msg" style="margin-top:10px">Resolving latest creator + items from analytics…</div>
+    <div class="pane left">
+      <h2><span class="badge">①</span> TikTok Shop · Order list <span id="ol-count" style="color:#9aa6bd"></span></h2>
+      <div id="orderlist"></div>
+    </div>
+    <div class="pane right">
+      <div class="kiosk-head"><h1>Samples</h1><span class="sub" id="kiosk-sub">loading…</span></div>
+      <div id="kiosk"><div class="kiosk-loading"><div class="spinner"></div><div>Loading Inventory Manager…</div></div></div>
+    </div>
+  </div>
+
+  <!-- eBay draft overlay -->
+  <div class="ebay-ov" id="ebay-ov"><div class="ebd" id="ebd"></div></div>
+
+  <!-- mark-as-sold dialog -->
+  <div class="sold-ov" id="sold-ov">
+    <div class="sold-dlg">
+      <h3><span class="tag">🏷</span> Mark as Sold</h3>
+      <div class="sold-card"><div class="nm" id="sold-nm"></div><div class="br" id="sold-br"></div></div>
+      <div class="sold-fld"><label>Your Name (Operator) *</label><div class="inp">DJ</div></div>
+      <div class="sold-fld"><label>Buyer *</label><div class="inp">eBay</div></div>
+      <div class="sold-fld"><label>Sold Price *</label><div class="inp" id="sold-price">$0.00</div></div>
+      <button class="sold-btn" id="sold-btn">Mark as Sold</button>
+    </div>
+  </div>
+
+  <!-- Price-Is-Right showcase -->
+  <div class="showcase" id="showcase">
+    <div class="bulbs top"></div><div class="bulbs bot"></div>
+    <div class="sc-title">Today's Sample Showcase</div>
+    <div class="sc-sub">one batch · $0 paid · followed end-to-end</div>
+    <div class="sc-lots">
+      <div class="sc-lot value" id="lot-value">
+        <div class="ico">📦</div>
+        <div class="t"><div class="h">Free sample haul</div><div class="d">retail value that would've been on your share screen</div></div>
+        <div class="v" id="lot-value-amt">$0</div>
+      </div>
+      <div class="sc-lot profit" id="lot-profit">
+        <div class="ico">💸</div>
+        <div class="t"><div class="h">Resold on eBay</div><div class="d">marketplace profit, net of fees · cost $0</div></div>
+        <div class="v" id="lot-profit-amt">$0</div>
       </div>
     </div>
-  </div>
-
-  <!-- Controls collapsed behind this toggle by default so they don't block the
-       demo; auto-revealed when a run finishes. -->
-  <button class="infobtn hint" id="infobtn" type="button"
-    title="Show demo controls (creator, dry-run, replay)" aria-label="Toggle demo controls">i</button>
-
-  <div class="bar" id="bar">
-    <div class="logo">▶</div>
-    <div>
-      <div class="title">E2E · Sample Lifecycle Demo</div>
-      <div class="sub">Resolves the latest creator's recent items (or a default product) and runs the import live.</div>
-    </div>
-    <div class="ctx">
-      <span class="chip" id="ctx-creator">creator: …</span>
-      <span class="chip" id="ctx-ids">items: …</span>
-      <span class="chip" id="ctx-source">source: …</span>
-      <label class="toggle" title="Dry-run computes the campaign/enrichment and shows the flow, but writes no inventory.">
-        <input type="checkbox" id="dry" checked /> Dry-run
-      </label>
-      <button id="rerun" type="button">↻ Replay</button>
+    <div class="sc-final" id="sc-final">
+      <div class="lab">Total value created</div>
+      <div class="amt" id="sc-final-amt">$0</div>
+      <div class="kick">free samples + resale — <b id="sc-margin">100%</b> margin on <b>$0</b> spent.</div>
     </div>
   </div>
+
+  <button class="replay" id="replay">↻ Replay</button>
+
+  <svg class="cursor" id="cursor" viewBox="0 0 24 24" fill="none"><path d="M5 3l14 8-6 1.5L9.5 18 5 3z" fill="#fff" stroke="#111" stroke-width="1.3" stroke-linejoin="round"/></svg>
+  <div class="ring" id="ring"></div>
 
   <script>
     "use strict";
-    // The Samples-Import demo lives on GH Pages; it reads ?ids/&creator/&autostart
-    // (and &api for the backend). It calls the live thirsty.store import API.
-    var IMPORT_BASE = "https://easierbycode.com/tok-scrape/samples-import/www/";
-    var IMPORT_ORIGIN = "https://easierbycode.com";
-    var API = location.origin; // served from thirsty.store → talk to the same backend
-    var esc = function (s) {
-      return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
-        return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    var usd = function (n) { return "$" + Number(n).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }); };
+    var sleep = function (ms) { return new Promise(function (r) { setTimeout(r, ms); }); };
+    var $ = function (id) { return document.getElementById(id); };
+
+    // Curated demo batch. The hero (Ninja) is the item walked through resale.
+    var ITEMS = [
+      { name: "Ninja AF101 Air Fryer 4qt", brand: "Ninja", retail: 89.99, emoji: "🍳", hero: true, salePrice: 72.00, fees: 9.36 },
+      { name: "Stanley Quencher H2.0 40oz", brand: "Stanley", retail: 45.00, emoji: "🥤" },
+      { name: "CeraVe Moisturizing Bundle", brand: "CeraVe", retail: 38.99, emoji: "🧴" },
+      { name: "Olaplex No.3 Hair Perfector", brand: "Olaplex", retail: 30.00, emoji: "💆" },
+      { name: "Tide PODS (81 ct)", brand: "Tide", retail: 24.99, emoji: "🧺" },
+      { name: "Crest 3D White (3-pack)", brand: "Crest", retail: 14.97, emoji: "🪥" }
+    ];
+    var TILE = ["#3a2a5e", "#264a63", "#5e2a3a", "#2a5e4a", "#5e4a2a", "#2a3a5e"];
+    var hero = ITEMS.find(function (i) { return i.hero; });
+    var SAMPLE_VALUE = ITEMS.reduce(function (s, i) { return s + i.retail; }, 0);          // 243.94
+    var PROFIT = +(hero.salePrice - hero.fees).toFixed(2);                                  // 62.64
+    var TOTAL = +(SAMPLE_VALUE + PROFIT).toFixed(2);                                         // 306.58
+
+    var cursor = $("cursor"), ring = $("ring");
+    function moveTo(el, fast) {
+      var r = el.getBoundingClientRect();
+      cursor.classList.toggle("fast", !!fast);
+      cursor.style.transform = "translate(" + (r.left + r.width / 2 - 3) + "px," + (r.top + r.height / 2 - 2) + "px)";
+    }
+    function clickAt() {
+      var m = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(cursor.style.transform || "");
+      var x = m ? +m[1] + 3 : 0, y = m ? +m[2] + 2 : 0;
+      ring.style.left = x + "px"; ring.style.top = y + "px";
+      ring.classList.remove("go"); void ring.offsetWidth; ring.classList.add("go");
+    }
+    async function clickEl(el, fast) { moveTo(el, fast); await sleep(fast ? 480 : 740); clickAt(); await sleep(180); }
+
+    function animateCount(el, from, to, ms, fmt) {
+      fmt = fmt || usd; var start = null;
+      return new Promise(function (res) {
+        function tick(t) {
+          if (start === null) start = t;
+          var p = Math.min(1, (t - start) / ms), e = 1 - Math.pow(1 - p, 3);
+          el.textContent = fmt(from + (to - from) * e);
+          if (p < 1) requestAnimationFrame(tick); else res();
+        }
+        requestAnimationFrame(tick);
       });
-    };
-
-    var bar = document.getElementById("bar");
-    var infobtn = document.getElementById("infobtn");
-    function showBar() { bar.classList.add("shown"); infobtn.classList.add("is-open"); infobtn.classList.remove("hint"); }
-    function hideBar() { bar.classList.remove("shown"); infobtn.classList.remove("is-open"); }
-    infobtn.addEventListener("click", function () {
-      bar.classList.contains("shown") ? hideBar() : showBar();
-    });
-
-    // The embedded Samples-Import posts {source:"samples-import",type:"imported"}
-    // to this window when a batch finishes — reveal the controls so the user can
-    // inspect the result, replay, or flip dry-run/live.
-    window.addEventListener("message", function (e) {
-      if (e.origin !== IMPORT_ORIGIN) return;
-      if (!e.data || e.data.source !== "samples-import" || e.data.type !== "imported") return;
-      showBar();
-    });
-
-    function setChips(ctx) {
-      document.getElementById("ctx-creator").innerHTML = "creator: <b>" + esc(ctx.creator) + "</b>";
-      document.getElementById("ctx-ids").innerHTML =
-        "items: <b>" + (ctx.ids ? ctx.ids.length : 0) + "</b> (" +
-        esc((ctx.ids || []).join(", ")) + ")";
-      document.getElementById("ctx-source").innerHTML = "source: <b>" + esc(ctx.source) + "</b>";
     }
 
-    function runDemo(ctx) {
-      setChips(ctx);
-      var u = new URL(IMPORT_BASE);
-      u.searchParams.set("api", API);
-      u.searchParams.set("autostart", "1");
-      u.searchParams.set("creator", ctx.creator);
-      u.searchParams.set("ids", (ctx.ids || []).join(","));
-      // Default: dry-run (no inventory written). Uncheck to run a real import.
-      if (document.getElementById("dry").checked) u.searchParams.set("dryrun", "1");
-      var iframe = document.getElementById("demo");
-      var overlay = document.getElementById("overlay");
-      iframe.addEventListener("load", function () { overlay.classList.add("hidden"); }, { once: true });
-      // Safety net for cross-origin load events that don't fire.
-      setTimeout(function () { overlay.classList.add("hidden"); }, 6000);
-      iframe.src = u.toString();
+    var orderListEl = $("orderlist"), kioskEl = $("kiosk"), tallyEl = $("tally");
+
+    function buildOrderList() {
+      orderListEl.innerHTML = "";
+      ITEMS.forEach(function (it, i) {
+        var row = document.createElement("div");
+        row.className = "order"; row.dataset.i = i;
+        row.innerHTML =
+          '<div class="thumb" style="background:' + TILE[i] + '">' + it.emoji + "</div>" +
+          '<div class="meta"><div class="nm">' + it.name + '</div><div class="br">' + it.brand + " · TikTok Shop</div></div>" +
+          '<div class="vals"><div class="paid">paid $0.00</div><div class="retail">' + usd(it.retail) + "</div></div>" +
+          '<div class="check">✓</div>';
+        orderListEl.appendChild(row);
+      });
     }
 
-    function load() {
-      var overlay = document.getElementById("overlay");
-      var msg = document.getElementById("overlay-msg");
-      overlay.classList.remove("hidden");
-      msg.textContent = "Resolving latest creator + items from analytics…";
-      fetch(API + "/api/e2e-context")
-        .then(function (r) { return r.json(); })
-        .then(function (ctx) {
-          if (!ctx || !ctx.creator || !ctx.ids || !ctx.ids.length) {
-            ctx = { creator: "@e2e-demo", ids: ["1731301163454206492"], source: "default (client fallback)" };
-          }
-          runDemo(ctx);
-        })
-        .catch(function () {
-          runDemo({ creator: "@e2e-demo", ids: ["1731301163454206492"], source: "default (offline)" });
-        });
+    function buildKiosk() {
+      kioskEl.innerHTML = '<div class="grid" id="grid"></div>';
+      var grid = $("grid");
+      ITEMS.forEach(function (it, i) {
+        var c = document.createElement("div");
+        c.className = "kcard" + (it.hero ? " hero" : ""); c.dataset.i = i;
+        c.innerHTML =
+          '<div class="img" style="background:' + TILE[i] + '">' + it.emoji +
+            '<span class="sbadge available">● Available</span>' +
+            '<button class="draftbtn">eBay draft</button></div>' +
+          '<div class="body"><div class="nm">' + it.name + '</div><div class="br">' + it.brand + '</div>' +
+            '<div class="pr">' + usd(it.retail) + '</div></div>';
+        grid.appendChild(c);
+      });
     }
 
-    document.getElementById("rerun").addEventListener("click", function () {
-      // Re-resolve context (a newer creator may have posted) and reload the demo.
-      var iframe = document.getElementById("demo");
-      iframe.removeAttribute("src");
-      load();
-    });
+    // ---------- phases ----------
+    async function phaseOrderList() {
+      buildOrderList();
+      var rows = orderListEl.querySelectorAll(".order");
+      $("ol-count").textContent = "· " + ITEMS.length + " items";
+      for (var i = 0; i < rows.length; i++) { rows[i].classList.add("in"); await sleep(120); }
+      await sleep(400);
+      var running = 0;
+      for (var j = 0; j < rows.length; j++) {
+        await clickEl(rows[j], j > 0);
+        rows[j].classList.add("clicked");
+        var from = running; running += ITEMS[j].retail;
+        await animateCount(tallyEl, from, running, 420);
+        await sleep(120);
+      }
+      tallyEl.textContent = usd(SAMPLE_VALUE);
+      await sleep(500);
+    }
 
-    // Toggling Dry-run/Live re-runs in the chosen mode (Live writes inventory).
-    document.getElementById("dry").addEventListener("change", function () {
-      var iframe = document.getElementById("demo");
-      iframe.removeAttribute("src");
-      load();
-    });
+    async function phaseKioskRefresh() {
+      $("kiosk-sub").textContent = "refreshing…";
+      buildKiosk();
+      $("kiosk-sub").textContent = ITEMS.length + " of " + ITEMS.length + " samples";
+      var cards = kioskEl.querySelectorAll(".kcard");
+      for (var i = 0; i < cards.length; i++) { cards[i].classList.add("in"); await sleep(110); }
+      await sleep(700);
+    }
 
-    load();
+    function heroCard() { return kioskEl.querySelector(".kcard.hero"); }
+
+    async function phaseClearToSell() {
+      var card = heroCard(); card.classList.add("focus");
+      var badge = card.querySelector(".sbadge");
+      await clickEl(badge);
+      badge.classList.remove("available"); badge.classList.add("cleared");
+      badge.innerHTML = "🌱 Cleared to Sell";
+      card.classList.add("cleared"); // reveals the eBay draft button
+      await sleep(900);
+    }
+
+    async function phaseEbayDraft() {
+      var card = heroCard();
+      await clickEl(card.querySelector(".draftbtn"));
+      $("ebd").innerHTML =
+        '<div class="ebd-top"><span class="ebd-logo"><span class="e">e</span><span class="b">b</span><span class="a">a</span><span class="y">y</span></span>' +
+          '<span class="ebd-h">Create your listing</span><span class="ebd-x">✕</span></div>' +
+        '<div class="ebd-banner">✎ Draft from sample "' + hero.name + '" — tap a field to autofill, or open it in eBay.</div>' +
+        '<div class="ebd-body">' +
+          '<div class="ebd-fld"><label>Photos</label><div class="ebd-box" id="f0"><span class="ebd-ph" style="background:' + TILE[0] + '">' + hero.emoji + '</span></div><span class="ebd-chip">☝ autofill photo</span></div>' +
+          '<div class="ebd-fld"><label>Listing title</label><div class="ebd-box" id="f1">' + hero.name + '</div><span class="ebd-chip">☝ autofill title</span></div>' +
+          '<div class="ebd-row"><div class="ebd-fld"><label>Condition</label><div class="ebd-box" id="f2"><span class="ebd-pill">New</span></div><span class="ebd-chip">☝ autofill</span></div>' +
+          '<div class="ebd-fld"><label>Price · Buy It Now</label><div class="ebd-box" id="f3">' + usd(hero.salePrice) + '</div><span class="ebd-chip">☝ autofill price</span></div></div>' +
+          '<div class="ebd-fld"><label>Description</label><div class="ebd-box" id="f4" style="color:#444;line-height:1.55">Brand-new, sealed TikTok Shop sample. Ships same-day from a smoke-free home. See item specifics for details.</div><span class="ebd-chip">☝ autofill description</span></div>' +
+        '</div>' +
+        '<div class="ebd-foot"><span class="ebd-meta">1 photo · ' + usd(hero.salePrice) + ' · productId 1731301163454206492</span>' +
+          '<button class="ebd-open" id="ebd-open">Open in eBay &amp; autofill ↗</button></div>';
+      $("ebay-ov").classList.add("show");
+      await sleep(500);
+      for (var k = 0; k < 5; k++) {
+        var box = $("f" + k); await clickEl(box, true);
+        box.classList.add("flash"); await sleep(260); box.classList.remove("flash");
+      }
+      var open = $("ebd-open"); await clickEl(open);
+      open.classList.add("flash"); open.textContent = "Listing on eBay… ↗";
+      await sleep(900);
+      $("ebay-ov").classList.remove("show");
+      await sleep(700); // short pause
+    }
+
+    async function phaseMarkSold() {
+      var card = heroCard();
+      await clickEl(card.querySelector(".sbadge"));
+      $("sold-nm").textContent = hero.name; $("sold-br").textContent = hero.brand;
+      $("sold-price").textContent = usd(hero.salePrice);
+      $("sold-ov").classList.add("show");
+      await sleep(700);
+      await clickEl($("sold-btn"));
+      $("sold-ov").classList.remove("show");
+      var badge = card.querySelector(".sbadge");
+      badge.classList.remove("cleared"); badge.classList.add("sold"); badge.innerHTML = "● Sold";
+      card.querySelector(".pr").innerHTML = '<span style="text-decoration:line-through;color:#6b768c">' + usd(hero.retail) + '</span> &nbsp;<span class="sold">Sold ' + usd(hero.salePrice) + " · eBay</span>";
+      card.classList.remove("focus");
+      await sleep(900); // one last short pause
+    }
+
+    async function phaseShowcase() {
+      $("showcase").classList.add("show");
+      await sleep(500);
+      $("lot-value").classList.add("in");
+      await animateCount($("lot-value-amt"), 0, SAMPLE_VALUE, 700, usd);
+      await sleep(500);
+      $("lot-profit").classList.add("in");
+      await animateCount($("lot-profit-amt"), 0, PROFIT, 700, function (v) { return "+" + usd(v); });
+      await sleep(600);
+      $("sc-final").classList.add("in");
+      await animateCount($("sc-final-amt"), 0, TOTAL, 900, usd);
+      await sleep(300);
+      $("replay").classList.add("show");
+    }
+
+    async function run() {
+      $("showcase").classList.remove("show"); $("ebay-ov").classList.remove("show"); $("sold-ov").classList.remove("show");
+      $("replay").classList.remove("show");
+      ["lot-value", "lot-profit", "sc-final"].forEach(function (id) { $(id).classList.remove("in"); });
+      $("lot-value-amt").textContent = "$0"; $("lot-profit-amt").textContent = "$0"; $("sc-final-amt").textContent = "$0";
+      tallyEl.textContent = "$0.00";
+      kioskEl.innerHTML = '<div class="kiosk-loading"><div class="spinner"></div><div>Loading Inventory Manager…</div></div>';
+      $("kiosk-sub").textContent = "loading…";
+      moveTo($("creator"));
+      await sleep(400);
+      await phaseOrderList();
+      await phaseKioskRefresh();
+      await phaseClearToSell();
+      await phaseEbayDraft();
+      await phaseMarkSold();
+      await phaseShowcase();
+    }
+
+    $("replay").addEventListener("click", run);
+    // Flavor: use the latest real creator handle if available (non-blocking).
+    fetch("/api/e2e-context").then(function (r) { return r.json(); }).then(function (c) {
+      if (c && c.creator) $("creator").innerHTML = "creator <b>" + String(c.creator).replace(/[<>]/g, "") + "</b>";
+    }).catch(function () {});
+    run();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## What
Rebuilds the E2E demo as a self-contained, scripted **lifecycle "movie"** (no iframes — full timing control, same-origin), replicating the Sample Valuation reveal at the start and walking the whole lifecycle with a fake cursor:

1. **Order list + tally** — TikTok order rows fade in; a fake cursor auto-clicks each, and the **Sample value** odometer climbs (replicates the Sample Valuation tally).
2. **Kiosk refresh** (replaces the share image) — the right pane reloads into a kiosk product grid showing all the items (dark shadcn cards + green Available badges).
3. **Cleared to Sell** — fake cursor toggles the hero item's status badge to **Cleared to Sell** (green); the eBay-draft button appears.
4. **eBay draft** — clicks it → the eBay "Create your listing" overlay (eBay wordmark, pulsing tap-to-autofill chips, Condition New, price); cursor flashes each field then **Open in eBay & autofill**.
5. **Sold** — short pause, back to inventory; cursor opens the sky-blue **Mark as Sold** dialog → badge flips to **Sold** + "Sold $72.00 · eBay".
6. **Price-Is-Right showcase** — final purple/gold reveal: **sample retail value** (the share-screen $) + **marketplace profit** (net of fees), climbing odometers → **Total value created** finale. A **Replay** button appears.

Visuals lifted to match the real surfaces: showcase (samples-modal purple/gold/bulbs), kiosk cards + status pills (cleared_to_sell green / sold sky), and the eBay-draft overlay. Fully self-contained (no live writes); pulls a real creator handle from `/api/e2e-context` for flavor (non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
