### PR TITLE
Sample valuation instances: persist raw inputs to Graylog, recompute later with changed variables

### DIFF
--- a/.claude/skills/sample-lifecycle/references/lifecycle-events.md
+++ b/.claude/skills/sample-lifecycle/references/lifecycle-events.md
@@ -202,3 +202,34 @@ name only), so "order received → which content sold it" can't be joined
 automatically yet. Closing that needs the order scraper to capture a productId —
 out of scope for this skill. Until then, that hop is matched manually by product
 name against the catalog (`/api/products`).
+
+## Event 6 — sample valuation instance (recomputable)
+
+`recordSampleValuation` (`POST /api/sample-valuation/record`, MCP
+`record_sample_valuation`) snapshots a valuation to Graylog with **all raw inputs
+needed to recompute it later**, keyed by a `valuation_id` (+ `valuation_revision_num`).
+The live read (`GET /api/sample-valuation`, `fetchSampleValuation`) is unchanged —
+this is purely additive persistence.
+
+| field | type | meaning |
+| --- | --- | --- |
+| `sample_valuation_json` | JSON string | `{valuationId, revision, recordedAt, recomputedFrom?, params, items[], totals}` |
+| `valuation_id` | string | instance id (`val-<uuid>`) |
+| `valuation_revision_num` | number | 0 for the snapshot; +1 per recompute |
+| `retail_value_num` / `resale_value_num` / `net_num` / `cost_num` | number | flat totals for `--terms`/aggregation |
+
+`items[]` are the recompute fuel — per product: `productId, name, category,
+sampleCount, unitRetail, retailValue, cost, resaleRate?, affiliateRate?, affiliateLink?`.
+`params` = `{defaultResaleRate, resaleRates[3], maintainableCap, currency}`. Totals are
+**derived** (`computeValuationTotals`) so headline numbers match `fetchSampleValuation`;
+extra fields (`resaleValue` at the per-item rate, `affiliateValue`, `netValue`, `totalCost`)
+are additive.
+
+**Recompute later with changed variables** — `recomputeSampleValuation`
+(`POST /api/sample-valuation/recompute`, MCP `recompute_sample_valuation`): fetch the
+stored instance and `addItems` / `updateItems` (e.g. a product's `resaleRate` or
+`affiliateRate` for a different affiliate link) / `removeProductIds` / change `params`,
+and it re-derives the totals. Persists a new revision by default (`recomputedFrom`
+links it), so each scenario is itself queryable; `persist:false` for a preview.
+Query a period's valuations: `sample_valuation_json:*`, group by `valuation_id`,
+take max `valuation_revision_num`.

--- a/core/graylog.ts
+++ b/core/graylog.ts
@@ -56,6 +56,54 @@ export type SampleValuation = {
   lastUpdated: string | null;
 };
 
+// A persisted sample-valuation INSTANCE keeps every raw input needed to recompute
+// the valuation later under changed variables (add/remove a product, change a
+// product's resale or affiliate rate). Stored to Graylog as sample_valuation_json
+// keyed by valuation_id (+revision) so a scenario can be re-queried and re-run.
+export type ValuationItem = {
+  productId: string;
+  name?: string;
+  category?: string;
+  sampleCount: number; // units of this product sampled
+  unitRetail: number; // per-unit retail $
+  retailValue: number; // total retail $ for the line (sampleCount * unitRetail unless overridden)
+  cost?: number; // total cost paid for the line (free samples = 0)
+  resaleRate?: number; // product-specific resale fraction (else params.defaultResaleRate)
+  affiliateRate?: number; // commission fraction if resold via an affiliate link
+  affiliateLink?: string;
+};
+export type ValuationParams = {
+  defaultResaleRate: number;
+  resaleRates: number[]; // the [10%, 20%, 30%] outputs, configurable
+  maintainableCap: number;
+  currency: string;
+};
+export type ValuationTotals = {
+  totalSamples: number;
+  productsTracked: number;
+  totalRetailValue: number;
+  totalCost: number;
+  averageSampleValue: number;
+  maintainableMonthlyValue: number;
+  resale10Value: number;
+  resale20Value: number;
+  resale30Value: number;
+  resaleValue: number; // at the (per-item or default) resale rate
+  affiliateValue: number;
+  netValue: number; // resaleValue - totalCost
+};
+export type ValuationInstance = {
+  valuationId: string;
+  revision: number;
+  recordedAt: string;
+  recomputedFrom?: string;
+  note?: string;
+  source?: string;
+  params: ValuationParams;
+  items: ValuationItem[];
+  totals: ValuationTotals;
+};
+
 type GraylogTabularResponse = {
   schema?: Array<{ field?: string }>;
   datarows?: unknown[][];
@@ -750,6 +798,279 @@ export async function fetchSampleValuation(): Promise<SampleValuation> {
     resale20Value: totalRetailValue * 0.2,
     resale30Value: totalRetailValue * 0.3,
     lastUpdated,
+  };
+}
+
+const DEFAULT_VALUATION_PARAMS: ValuationParams = {
+  defaultResaleRate: 0.10,
+  resaleRates: [0.10, 0.20, 0.30],
+  maintainableCap: 5000,
+  currency: "USD",
+};
+function vnum(v: unknown, d = 0): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+function normalizeValuationItem(it: ValuationItem): ValuationItem {
+  const sampleCount = vnum(it.sampleCount, 1) || 1;
+  const unitRetail = vnum(it.unitRetail, 0);
+  const retailValue = it.retailValue != null ? vnum(it.retailValue) : sampleCount * unitRetail;
+  return {
+    productId: String(it.productId || "").trim(),
+    name: it.name,
+    category: it.category,
+    sampleCount,
+    unitRetail: unitRetail || (sampleCount ? retailValue / sampleCount : 0),
+    retailValue,
+    cost: it.cost != null ? vnum(it.cost) : 0,
+    resaleRate: it.resaleRate != null ? vnum(it.resaleRate) : undefined,
+    affiliateRate: it.affiliateRate != null ? vnum(it.affiliateRate) : undefined,
+    affiliateLink: it.affiliateLink,
+  };
+}
+
+// Pure: derive every valuation total from the raw line items + params. This is
+// the recompute engine — change a per-item resale/affiliate rate, add or remove a
+// product, or tweak params, and the totals follow with NO re-scrape. The headline
+// fields (totalSamples/totalRetailValue/resale10|20|30) match fetchSampleValuation
+// so a recorded instance reproduces the current output; the rest are additive.
+export function computeValuationTotals(
+  items: ValuationItem[],
+  params: ValuationParams,
+): ValuationTotals {
+  const rates = params.resaleRates && params.resaleRates.length >= 3
+    ? params.resaleRates
+    : [0.10, 0.20, 0.30];
+  let totalSamples = 0, totalRetailValue = 0, totalCost = 0, resaleValue = 0, affiliateValue = 0;
+  for (const raw of items) {
+    const it = normalizeValuationItem(raw);
+    const retail = it.retailValue;
+    const rRate = it.resaleRate != null ? it.resaleRate : params.defaultResaleRate;
+    totalSamples += it.sampleCount;
+    totalRetailValue += retail;
+    totalCost += vnum(it.cost);
+    resaleValue += retail * rRate;
+    affiliateValue += retail * vnum(it.affiliateRate);
+  }
+  const r2 = (n: number) => Math.round(n * 100) / 100;
+  return {
+    totalSamples,
+    productsTracked: items.length,
+    totalRetailValue: r2(totalRetailValue),
+    totalCost: r2(totalCost),
+    averageSampleValue: totalSamples ? r2(totalRetailValue / totalSamples) : 0,
+    maintainableMonthlyValue: r2(Math.min(totalRetailValue, params.maintainableCap)),
+    resale10Value: r2(totalRetailValue * rates[0]),
+    resale20Value: r2(totalRetailValue * rates[1]),
+    resale30Value: r2(totalRetailValue * rates[2]),
+    resaleValue: r2(resaleValue),
+    affiliateValue: r2(affiliateValue),
+    netValue: r2(resaleValue - totalCost),
+  };
+}
+
+async function emitValuation(inst: ValuationInstance): Promise<boolean> {
+  return await sendGelfMessage(
+    `thirsty sample valuation ${inst.valuationId} rev${inst.revision}: $${
+      inst.totals.totalRetailValue.toFixed(2)
+    } retail`,
+    {
+      sample_valuation_json: JSON.stringify(inst),
+      valuation_id: inst.valuationId,
+      valuation_revision_num: inst.revision,
+      recomputed_from: inst.recomputedFrom || undefined,
+      sample_count_num: inst.totals.totalSamples,
+      products_tracked_num: inst.totals.productsTracked,
+      retail_value_num: inst.totals.totalRetailValue,
+      resale_value_num: inst.totals.resaleValue,
+      resale10_num: inst.totals.resale10Value,
+      affiliate_value_num: inst.totals.affiliateValue,
+      cost_num: inst.totals.totalCost,
+      net_num: inst.totals.netValue,
+      currency: inst.params.currency,
+      sample_source: "valuation",
+    },
+  );
+}
+
+export type RecordValuationInput = {
+  valuationId?: string;
+  items?: ValuationItem[];
+  params?: Partial<ValuationParams>;
+  note?: string;
+  source?: string;
+};
+
+// Snapshot a sample valuation to Graylog with ALL raw inputs (per-product line
+// items + params + computed totals) under a valuation_id, revision 0. Without
+// `items` it snapshots the live product-derived valuation (same numbers as
+// fetchSampleValuation). The point is recomputability later — see recompute.
+export async function recordSampleValuation(
+  input: RecordValuationInput = {},
+): Promise<
+  {
+    ok: boolean;
+    valuationId: string;
+    revision: number;
+    itemCount: number;
+    totals: ValuationTotals;
+    graylog: boolean;
+    message: string;
+  }
+> {
+  const params: ValuationParams = { ...DEFAULT_VALUATION_PARAMS, ...(input.params || {}) };
+  let items: ValuationItem[];
+  if (Array.isArray(input.items)) {
+    items = input.items.map(normalizeValuationItem);
+  } else {
+    const products = await fetchRecentProducts(500);
+    items = products.map((p) =>
+      normalizeValuationItem({
+        productId: String(p.productId),
+        name: p.name,
+        category: p.category,
+        sampleCount: vnum(p.sampleCount, 0),
+        unitRetail: vnum(p.min_sku_original_price, 0),
+        retailValue: vnum(
+          p.estimatedRetailValue,
+          vnum(p.sampleCount) * vnum(p.min_sku_original_price),
+        ),
+        cost: 0,
+      })
+    );
+  }
+  const totals = computeValuationTotals(items, params);
+  const valuationId = String(input.valuationId || "").trim() || `val-${crypto.randomUUID()}`;
+  const graylog = await emitValuation({
+    valuationId,
+    revision: 0,
+    recordedAt: new Date().toISOString(),
+    note: input.note,
+    source: input.source || "snapshot",
+    params,
+    items,
+    totals,
+  });
+  return {
+    ok: graylog,
+    valuationId,
+    revision: 0,
+    itemCount: items.length,
+    totals,
+    graylog,
+    message: `Recorded valuation ${valuationId}: ${items.length} products, $${
+      totals.totalRetailValue.toFixed(2)
+    } retail across ${totals.totalSamples} samples${graylog ? "" : " (Graylog write FAILED)"}.`,
+  };
+}
+
+// Latest stored revision of a valuation instance (its raw items + params + totals).
+export async function fetchSampleValuationInstance(
+  valuationId: string,
+): Promise<ValuationInstance | null> {
+  const config = graylogConfigFromEnv();
+  const id = String(valuationId || "").trim();
+  if (!config || !id) return null;
+  try {
+    const wide: GraylogConfig = { ...config, rangeSeconds: 60 * 60 * 24 * 365 * 5 };
+    const msgs = await searchGraylog(
+      wide,
+      `sample_valuation_json:* AND valuation_id:"${id.replace(/"/g, '\\"')}"`,
+      200,
+      ["timestamp", "valuation_id", "valuation_revision_num", "sample_valuation_json"],
+    );
+    let best: ValuationInstance | null = null;
+    for (const m of msgs) {
+      const rec = parseJsonValue(m.sample_valuation_json);
+      if (!isRecord(rec)) continue;
+      const inst = rec as unknown as ValuationInstance;
+      if (!best || vnum(inst.revision) > vnum(best.revision)) best = inst;
+    }
+    return best;
+  } catch {
+    return null;
+  }
+}
+
+export type RecomputeOverrides = {
+  addItems?: ValuationItem[];
+  updateItems?: Array<Partial<ValuationItem> & { productId: string }>;
+  removeProductIds?: string[];
+  params?: Partial<ValuationParams>;
+  persist?: boolean; // default true → save the new scenario as a queryable revision
+  note?: string;
+};
+
+// Re-run a stored valuation with changed variables — add/update/remove products,
+// change a product's resale or affiliate rate, or tweak params — and get base vs
+// recomputed totals. By default persists the result as a new revision under the
+// same valuation_id (recomputedFrom links it), so every scenario is itself stored
+// and queryable. Pass persist:false for a non-destructive preview.
+export async function recomputeSampleValuation(
+  valuationId: string,
+  overrides: RecomputeOverrides = {},
+): Promise<
+  | {
+    ok: true;
+    valuationId: string;
+    revision: number;
+    base: ValuationTotals;
+    totals: ValuationTotals;
+    itemCount: number;
+    graylog: boolean;
+    message: string;
+  }
+  | { ok: false; error: string }
+> {
+  const base = await fetchSampleValuationInstance(valuationId);
+  if (!base) {
+    return { ok: false, error: `No stored valuation instance for valuation_id "${valuationId}"` };
+  }
+  const remove = new Set((overrides.removeProductIds || []).map((s) => String(s)));
+  let items = base.items.filter((it) => !remove.has(String(it.productId)));
+  if (overrides.updateItems && overrides.updateItems.length) {
+    const byId = new Map(items.map((it) => [String(it.productId), { ...it }]));
+    for (const u of overrides.updateItems) {
+      const cur = byId.get(String(u.productId));
+      if (cur) byId.set(String(u.productId), normalizeValuationItem({ ...cur, ...u }));
+    }
+    items = [...byId.values()];
+  }
+  if (overrides.addItems && overrides.addItems.length) {
+    items = items.concat(overrides.addItems.map(normalizeValuationItem));
+  }
+  const params: ValuationParams = { ...base.params, ...(overrides.params || {}) };
+  const totals = computeValuationTotals(items, params);
+  const revision = vnum(base.revision) + 1;
+  let graylog = false;
+  if (overrides.persist !== false) {
+    graylog = await emitValuation({
+      valuationId: base.valuationId,
+      revision,
+      recordedAt: new Date().toISOString(),
+      recomputedFrom: `${base.valuationId}@rev${base.revision}`,
+      note: overrides.note,
+      source: "recompute",
+      params,
+      items,
+      totals,
+    });
+  }
+  return {
+    ok: true,
+    valuationId: base.valuationId,
+    revision,
+    base: base.totals,
+    totals,
+    itemCount: items.length,
+    graylog,
+    message: `Recomputed valuation ${base.valuationId} → rev${revision}: retail $${
+      base.totals.totalRetailValue.toFixed(2)
+    } → $${totals.totalRetailValue.toFixed(2)}, resale $${
+      base.totals.resaleValue.toFixed(2)
+    } → $${totals.resaleValue.toFixed(2)}${
+      overrides.persist === false ? " (preview — not saved)" : ""
+    }.`,
   };
 }
 

--- a/main.ts
+++ b/main.ts
@@ -42,7 +42,10 @@ import {
   fetchE2EContext,
   fetchKnownCreators,
   fetchOrderCreatorsByName,
+  fetchSampleValuationInstance,
   graylogConfigFromEnv,
+  recomputeSampleValuation,
+  recordSampleValuation,
 } from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
 
@@ -1329,6 +1332,50 @@ export async function legacyHandler(req: Request): Promise<Response> {
 
       if (pathname === "/api/sample-valuation") {
         return json(await fetchSampleValuationWithEdits());
+      }
+
+      // Persist a valuation INSTANCE (all raw inputs) so it can be recomputed
+      // later with changed variables. CORS — usable cross-origin from the demos.
+      if (pathname === "/api/sample-valuation/record") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "POST") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          return corsJson(await recordSampleValuation(await readJsonBody(req)));
+        } catch (error) {
+          return corsJson(
+            { ok: false, error: error instanceof Error ? error.message : String(error) },
+            400,
+          );
+        }
+      }
+      // Fetch the latest stored revision of a valuation instance.
+      if (pathname === "/api/sample-valuation/instance") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        return corsJson(
+          await fetchSampleValuationInstance(url.searchParams.get("id") || ""),
+        );
+      }
+      // Re-run a stored valuation with changed variables (add/update/remove
+      // products, change resale/affiliate rates or params). Body: { valuationId,
+      // addItems?, updateItems?, removeProductIds?, params?, persist?, note? }.
+      if (pathname === "/api/sample-valuation/recompute") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        if (req.method !== "POST") {
+          return corsJson({ ok: false, error: "Method not allowed" }, 405);
+        }
+        try {
+          const body = await readJsonBody(req) as Record<string, unknown>;
+          return corsJson(
+            await recomputeSampleValuation(String(body.valuationId || ""), body),
+          );
+        } catch (error) {
+          return corsJson(
+            { ok: false, error: error instanceof Error ? error.message : String(error) },
+            400,
+          );
+        }
       }
 
       // ---- Sample lifecycle (status changes + resale revenue) ----

--- a/mcp/thirsty-samples/server.ts
+++ b/mcp/thirsty-samples/server.ts
@@ -387,6 +387,56 @@ const TOOLS = [
       additionalProperties: false,
     },
   },
+  {
+    name: "record_sample_valuation",
+    description:
+      "Snapshot a sample valuation to Graylog with ALL raw inputs (per-product " +
+      "line items + params + computed totals) under a valuation_id, so it can be " +
+      "recomputed later with changed variables. Without `items`, snapshots the " +
+      "live product-derived valuation. Returns the valuationId + totals.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        valuationId: { type: "string", description: "Reuse/override the instance id (else generated)." },
+        items: {
+          type: "array",
+          description:
+            "Raw line items [{productId,name,sampleCount,unitRetail,retailValue,cost,resaleRate,affiliateRate,affiliateLink}]; omit to snapshot the live valuation.",
+          items: { type: "object" },
+        },
+        params: { type: "object", description: "{defaultResaleRate,resaleRates[3],maintainableCap,currency} overrides." },
+        note: { type: "string" },
+        source: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "recompute_sample_valuation",
+    description:
+      "Re-run a stored valuation with changed variables — add/update/remove " +
+      "products, change a product's resale or affiliate rate, or tweak params — " +
+      "and get base vs recomputed totals. Persists the scenario as a new revision " +
+      "by default (persist:false for a preview).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        valuationId: { type: "string", description: "The instance to recompute." },
+        addItems: { type: "array", items: { type: "object" }, description: "New line items to add." },
+        updateItems: {
+          type: "array",
+          items: { type: "object" },
+          description: "[{productId, ...fields}] to change (e.g. resaleRate, affiliateRate, retailValue).",
+        },
+        removeProductIds: { type: "array", items: { type: "string" } },
+        params: { type: "object", description: "Param overrides (e.g. defaultResaleRate)." },
+        persist: { type: "boolean", description: "Save as a new revision (default true)." },
+        note: { type: "string" },
+      },
+      required: ["valuationId"],
+      additionalProperties: false,
+    },
+  },
 ];
 
 const server = new Server(
@@ -540,6 +590,36 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             campaign: args.campaign,
             campaignId: args.campaignId,
             operator: args.operator,
+            note: args.note,
+          },
+        });
+        break;
+      }
+
+      case "record_sample_valuation": {
+        result = await api("/api/sample-valuation/record", {
+          method: "POST",
+          body: {
+            valuationId: args.valuationId,
+            items: args.items,
+            params: args.params,
+            note: args.note,
+            source: args.source,
+          },
+        });
+        break;
+      }
+
+      case "recompute_sample_valuation": {
+        result = await api("/api/sample-valuation/recompute", {
+          method: "POST",
+          body: {
+            valuationId: args.valuationId,
+            addItems: args.addItems,
+            updateItems: args.updateItems,
+            removeProductIds: args.removeProductIds,
+            params: args.params,
+            persist: args.persist,
             note: args.note,
           },
         });


### PR DESCRIPTION
## What
Persists a **sample-valuation instance** to Graylog with all raw inputs, so a valuation can be **recomputed later with changed variables** (add/remove a product, change a product's resale or affiliate rate, tweak params) — without re-scraping. The current valuation **output is unchanged**; this is purely additive.

### `core/graylog.ts`
- `computeValuationTotals(items, params)` — pure recompute engine. Headline totals (`totalSamples`, `totalRetailValue`, `resale10/20/30`) match `fetchSampleValuation`; extra fields (`resaleValue` at per-item rate, `affiliateValue`, `netValue`, `totalCost`) are additive.
- `recordSampleValuation(input)` — emits `sample_valuation_json` (revision 0) keyed by `valuation_id`, with per-product line items (`sampleCount, unitRetail, retailValue, cost, resaleRate?, affiliateRate?, affiliateLink?`) + params + totals. Without `items`, snapshots the live product-derived valuation.
- `fetchSampleValuationInstance(id)` — latest stored revision.
- `recomputeSampleValuation(id, overrides)` — `addItems`/`updateItems`/`removeProductIds`/`params`; re-derives totals; persists a new revision by default (`recomputedFrom` links it) so each scenario is itself queryable; `persist:false` for a preview.

### `main.ts` (CORS)
`POST /api/sample-valuation/record`, `GET /api/sample-valuation/instance?id=`, `POST /api/sample-valuation/recompute`. Existing `GET /api/sample-valuation` untouched.

### MCP + docs
`record_sample_valuation` + `recompute_sample_valuation` tools (thirsty-samples). New "Event 6" in the lifecycle-events reference.

`deno check` (main.ts + MCP server) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
