### PR TITLE
Valuation snapshot reproduces the edited (displayed) valuation

### DIFF
--- a/core/samples.ts
+++ b/core/samples.ts
@@ -7,6 +7,7 @@ import {
   fetchSampleEditRecords,
   type ProductAnalysis,
   type SampleValuation,
+  type ValuationItem,
   sendGelfMessage,
 } from "./graylog.ts";
 import { cacheGet, cacheSet, hashKey } from "./cache.ts";
@@ -1940,6 +1941,29 @@ export async function fetchSampleValuationWithEdits(): Promise<
     resale30Value: totalRetailValue * 0.3,
     lastUpdated,
   };
+}
+
+// The edited per-product line items behind fetchSampleValuationWithEdits — the
+// same product set + price/sampleCount edits the live valuation displays. Feeding
+// these to recordSampleValuation makes a snapshot reproduce exactly what the user
+// saw (so it can be recomputed later with changed variables).
+export async function fetchValuationLineItems(): Promise<ValuationItem[]> {
+  const store = await loadStore();
+  const products = await fetchProductsWithStored(1000, store);
+  return products
+    .filter((product) => product.sampleCount > 0)
+    .map((product) => {
+      const s = sampleFromProduct(product, store.edits[product.productId]);
+      return {
+        productId: String(s.productId),
+        name: s.name,
+        category: product.category,
+        sampleCount: s.sampleCount,
+        unitRetail: s.price,
+        retailValue: s.sampleValue,
+        cost: 0,
+      };
+    });
 }
 
 export async function fetchComparisonWithEdits(): Promise<ComparisonRow[]> {

--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ import {
   fetchPriceForSample,
   fetchProductWithEdits,
   fetchSampleValuationWithEdits,
+  fetchValuationLineItems,
   listSampleProducts,
   listUnpricedSamples,
   lookupProductByImage,
@@ -1342,7 +1343,11 @@ export async function legacyHandler(req: Request): Promise<Response> {
           return corsJson({ ok: false, error: "Method not allowed" }, 405);
         }
         try {
-          return corsJson(await recordSampleValuation(await readJsonBody(req)));
+          const body = await readJsonBody(req);
+          // No explicit items → snapshot the live (edited) valuation so the
+          // recorded instance reproduces what GET /api/sample-valuation shows.
+          if (!Array.isArray(body.items)) body.items = await fetchValuationLineItems();
+          return corsJson(await recordSampleValuation(body));
         } catch (error) {
           return corsJson(
             { ok: false, error: error instanceof Error ? error.message : String(error) },


### PR DESCRIPTION
## What
Makes a no-items valuation **snapshot reproduce exactly what `GET /api/sample-valuation` displays** (the edited valuation), so a recorded instance is faithful.

- `core/samples.ts`: `fetchValuationLineItems()` returns the edited per-product line items behind `fetchSampleValuationWithEdits` (same product set + price/sampleCount edits), shaped as `ValuationItem[]` (type-only import from graylog.ts — no circular dep).
- `main.ts`: `POST /api/sample-valuation/record` now defaults `items` to `fetchValuationLineItems()` when the body omits them — so the snapshot's totals equal the live edited valuation. Explicit `items` still override.

Follow-up to #89 (the round-trip math was already verified: record→fetch→recompute correct). `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
