### PR TITLE
Handle www.tiktok.com/t/<code> share links in Add-by-URL

### DIFF
--- a/core/product_by_url_test.ts
+++ b/core/product_by_url_test.ts
@@ -105,6 +105,44 @@ Deno.test("follows a short link server-side then extracts the id", async () => {
   }
 });
 
+Deno.test("follows a www.tiktok.com/t/<code> share link then extracts the id", async () => {
+  const realFetch = globalThis.fetch;
+  // The in-app share sheet hands out www.tiktok.com/t/ZP96… links: a short-link
+  // path on a regular TikTok host. It must be followed server-side just like the
+  // vt/vm short-link hosts.
+  globalThis.fetch = (() => {
+    const res = new Response("", { status: 200 });
+    Object.defineProperty(res, "url", {
+      value: `https://www.tiktok.com/shop/pdp/acme/${PRODUCT_ID}`,
+    });
+    return Promise.resolve(res);
+  }) as typeof fetch;
+  try {
+    const result = await resolveTiktokProductUrl(
+      "https://www.tiktok.com/t/ZP96abcdef/",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.productId).toBe(PRODUCT_ID);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+Deno.test("a share link that doesn't resolve to an id is a clean miss", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    const res = new Response("", { status: 200 });
+    Object.defineProperty(res, "url", { value: "https://www.tiktok.com/foryou" });
+    return Promise.resolve(res);
+  }) as typeof fetch;
+  try {
+    const result = await resolveTiktokProductUrl("https://www.tiktok.com/t/ZPbroken/");
+    expect(result.ok).toBe(false);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 Deno.test("a short link that doesn't resolve to an id is a clean miss", async () => {
   const realFetch = globalThis.fetch;
   globalThis.fetch = (() => {

--- a/core/samples.ts
+++ b/core/samples.ts
@@ -567,11 +567,27 @@ const TIKTOK_SHORTLINK_HOSTS = new Set([
   "t.tiktok.com",
 ]);
 
+// The in-app share sheet hands out www.tiktok.com/t/<code> links — a short-link
+// path on a regular TikTok host (not one of the dedicated short-link hosts).
+// Like the short-link hosts it carries no product id and 30x-redirects to the
+// real PDP, so it must be followed server-side too.
+const TIKTOK_SHARE_PATH = /^\/t\/[^/]+\/?$/i;
+
 // Accept tiktok.com and any subdomain (shop.tiktok.com, www.tiktok.com, the
 // short-link hosts, regional variants like shop.tiktok.com stay covered).
 function isTiktokHost(host: string): boolean {
   const h = host.toLowerCase();
   return h === "tiktok.com" || h.endsWith(".tiktok.com");
+}
+
+// A TikTok url that carries no id and must be resolved by following its redirect
+// server-side: either a dedicated short-link host (vt/vm/t.tiktok.com) or a
+// /t/<code> share path on any TikTok host (www.tiktok.com/t/ZP96…).
+function isTiktokShortLink(u: URL): boolean {
+  return (
+    TIKTOK_SHORTLINK_HOSTS.has(u.hostname.toLowerCase()) ||
+    TIKTOK_SHARE_PATH.test(u.pathname)
+  );
 }
 
 // Pull the numeric product id out of an already-final TikTok PDP url. Handles
@@ -659,18 +675,15 @@ export async function resolveTiktokProductUrl(
 
   // Short links carry no id; follow the redirect server-side and extract from
   // the resolved PDP url. Only trust a redirect that lands on a NON-short TikTok
-  // host — otherwise (network error, timeout, or a still-short url) the short
+  // url — otherwise (network error, timeout, or a still-short url) the short
   // code itself could be mis-read as a numeric id, so fail cleanly instead.
-  if (TIKTOK_SHORTLINK_HOSTS.has(u.hostname.toLowerCase())) {
+  if (isTiktokShortLink(u)) {
     let resolved = false;
     const finalUrl = await followShortLink(u.href);
     if (finalUrl) {
       try {
         const fu = new URL(finalUrl);
-        if (
-          isTiktokHost(fu.hostname) &&
-          !TIKTOK_SHORTLINK_HOSTS.has(fu.hostname.toLowerCase())
-        ) {
+        if (isTiktokHost(fu.hostname) && !isTiktokShortLink(fu)) {
           u = fu;
           resolved = true;
         }


### PR DESCRIPTION
## Problem

Pasting a TikTok in-app **share link** — `https://www.tiktok.com/t/ZP96…` — into the inventory Add-by-URL flow failed with:

> Couldn't find a TikTok product id in that link. Open the link and paste the full product URL (the one containing the long numeric id).

These share-sheet links are a short-link *path* (`/t/<code>`) on a regular TikTok host (`www.tiktok.com`), not one of the dedicated short-link hosts. They carry no product id and 30x-redirect to the real PDP, but `resolveTiktokProductUrl` only followed redirects for the `vt`/`vm`/`t.tiktok.com` hosts — so a `/t/` link was treated as a final PDP url, failed id extraction, and surfaced the error. The frontend's client-side fallback can't follow redirects either, hence the user-facing message in the screenshot.

## Change

- Add a `TIKTOK_SHARE_PATH` regex (`/^\/t\/[^/]+\/?$/i`) and a new `isTiktokShortLink(u)` helper that treats both the dedicated short-link hosts **and** the `/t/<code>` share path as links to resolve server-side.
- Use that helper for the follow-redirect decision **and** for the resolved-url acceptance check, so a redirect that lands back on a still-short url is still rejected cleanly (no mis-reading a short code as a numeric id).
- Add regression tests for a `/t/<code>` link that resolves to a PDP id and one that redirects to a non-product page (clean miss).

No frontend changes are needed: the Add-by-URL flow calls `/api/product-by-url` first, which now resolves these links.

## Testing

Added Deno tests in `core/product_by_url_test.ts`. Note: the test runner (`deno.land`) is blocked by this environment's network policy, so the suite could not be executed here — the new tests mirror the existing short-link test harness exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZK9c3DrqyeGuAGcm5JKAR)_