### PR TITLE
Sanitize DATABASE_URL so a stray quote/space can't become host "base"

### DIFF
--- a/core/db-url.ts
+++ b/core/db-url.ts
@@ -1,0 +1,59 @@
+// db-url.ts — read + sanitize DATABASE_URL before it reaches `pg`.
+//
+// Why this exists: `pg` parses the connection string with pg-connection-string,
+// which resolves the value relative to a dummy base URL `postgres://base`. So a
+// value that ISN'T recognized as an absolute `postgres://` URL keeps the base's
+// host — pg then tries to DNS-resolve the literal host "base" and the first
+// query dies with the cryptic `getaddrinfo ENOTFOUND base`.
+//
+// The usual culprits are paste mistakes in the deployment env UI: a leading
+// space, the value wrapped in quotes, or the whole `DATABASE_URL=…` line pasted
+// as the value. getDatabaseUrl() repairs those so a stray space/quote no longer
+// takes the site down; databaseUrlError() flags anything still malformed with a
+// human-readable reason instead of letting it degrade to "ENOTFOUND base".
+
+/**
+ * Read DATABASE_URL and repair common paste mistakes: surrounding whitespace, a
+ * leading `DATABASE_URL=` prefix, and a single layer of wrapping quotes.
+ * Returns null when the var is unset or (after cleaning) blank — callers treat
+ * that as "no local DB" (thin-client proxy mode).
+ */
+export function getDatabaseUrl(): string | null {
+  let v = Deno.env.get("DATABASE_URL");
+  if (v == null) return null;
+
+  // Trim, then drop an accidental `DATABASE_URL=` / `DATABASE_URL :` prefix
+  // (the whole KEY=VALUE line pasted as the value), then trim again.
+  v = v.trim().replace(/^DATABASE_URL\s*[=:]\s*/i, "").trim();
+
+  // Strip ONE layer of matching wrapping quotes (e.g. "postgres://…").
+  if (
+    v.length >= 2 &&
+    ((v[0] === '"' && v.at(-1) === '"') || (v[0] === "'" && v.at(-1) === "'"))
+  ) {
+    v = v.slice(1, -1).trim();
+  }
+
+  return v || null;
+}
+
+/**
+ * Validate a cleaned connection string. A pg connection string must be either an
+ * absolute `postgres://`/`postgresql://` URL or a `/unix/socket` path; anything
+ * else makes pg-connection-string fall back to host "base". Returns a
+ * human-readable error string when invalid, or null when it looks usable.
+ * (Returns a string instead of throwing so module init never crashes the
+ * isolate — boot stays non-blocking; the error surfaces on first query.)
+ */
+export function databaseUrlError(v: string): string | null {
+  if (v.startsWith("/")) return null; // unix-domain socket path
+  if (/^postgres(ql)?:\/\//i.test(v)) return null;
+  const head = JSON.stringify(v.slice(0, 16));
+  return (
+    `DATABASE_URL must start with "postgres://" or "postgresql://" ` +
+    `(or be a /socket path); got a value beginning with ${head}. ` +
+    `Check the deployment env for a leading space, surrounding quotes, or a ` +
+    `"DATABASE_URL=" prefix. Left as-is, pg resolves host "base" ` +
+    `(getaddrinfo ENOTFOUND base).`
+  );
+}

--- a/core/db-url_test.ts
+++ b/core/db-url_test.ts
@@ -1,0 +1,70 @@
+import { expect } from "@std/expect";
+import { databaseUrlError, getDatabaseUrl } from "./db-url.ts";
+
+const GOOD = "postgresql://user:pass@realhost.neon.tech:5432/neondb";
+
+// Set DATABASE_URL for the duration of fn, restoring it afterward.
+function withDbUrl<T>(value: string | undefined, fn: () => T): T {
+  const prev = Deno.env.get("DATABASE_URL");
+  try {
+    if (value === undefined) Deno.env.delete("DATABASE_URL");
+    else Deno.env.set("DATABASE_URL", value);
+    return fn();
+  } finally {
+    if (prev === undefined) Deno.env.delete("DATABASE_URL");
+    else Deno.env.set("DATABASE_URL", prev);
+  }
+}
+
+// Common env-UI paste mistakes that previously made pg resolve host "base" — all
+// must be repaired back to the original clean URL with no validation error.
+const REPAIRED: Array<[string, string]> = [
+  ["leading space", " " + GOOD],
+  ["trailing whitespace", GOOD + "  "],
+  ["wrapped double quotes", `"${GOOD}"`],
+  ["wrapped single quotes", `'${GOOD}'`],
+  ["DATABASE_URL= prefix", "DATABASE_URL=" + GOOD],
+  ["DATABASE_URL: prefix", "DATABASE_URL: " + GOOD],
+  ["quotes + whitespace", `  "${GOOD}"  `],
+];
+
+for (const [label, raw] of REPAIRED) {
+  Deno.test(`getDatabaseUrl repairs ${label}`, () => {
+    withDbUrl(raw, () => {
+      const url = getDatabaseUrl();
+      expect(url).toBe(GOOD);
+      expect(databaseUrlError(url!)).toBeNull();
+    });
+  });
+}
+
+// Absent / blank → null, so callers fall back to thin-client proxy mode.
+for (const [label, raw] of [
+  ["unset", undefined],
+  ["empty string", ""],
+  ["whitespace only", "   "],
+] as Array<[string, string | undefined]>) {
+  Deno.test(`getDatabaseUrl treats ${label} as null`, () => {
+    withDbUrl(raw, () => expect(getDatabaseUrl()).toBeNull());
+  });
+}
+
+// Present but not an absolute postgres URL → kept as-is, flagged with a reason.
+for (const [label, raw] of [
+  ["bare hostname", "realhost.neon.tech"],
+  ["scheme typo", "psql://user:pass@host:5432/db"],
+] as Array<[string, string]>) {
+  Deno.test(`databaseUrlError flags ${label}`, () => {
+    withDbUrl(raw, () => {
+      const url = getDatabaseUrl();
+      expect(url).toBe(raw);
+      const err = databaseUrlError(url!);
+      expect(err).toContain("postgres://");
+    });
+  });
+}
+
+Deno.test("databaseUrlError accepts a valid URL and a unix socket", () => {
+  expect(databaseUrlError(GOOD)).toBeNull();
+  expect(databaseUrlError("/var/run/postgresql")).toBeNull();
+});

--- a/db.ts
+++ b/db.ts
@@ -2,9 +2,18 @@
 // Fixes: created_date missing -> safe fallback, validates order_by + filters.
 
 import { Pool } from "npm:pg";
+import { databaseUrlError, getDatabaseUrl } from "./core/db-url.ts";
+
+// Cleaned once at module load (repairs stray quotes/whitespace/`DATABASE_URL=`
+// prefix). DB_URL_ERR is non-null when the value is unset or still malformed —
+// connect() throws it so a bad config fails with a clear message instead of the
+// cryptic `getaddrinfo ENOTFOUND base`. Computed here (no throw) so boot stays
+// non-blocking; see core/db-url.ts.
+const DB_URL = getDatabaseUrl();
+const DB_URL_ERR = DB_URL ? databaseUrlError(DB_URL) : "DATABASE_URL is not set";
 
 const pool = new Pool({
-  connectionString: Deno.env.get("DATABASE_URL"),
+  connectionString: DB_URL ?? undefined,
   max: 1,
   // Bound a stalled connection so a dead DB eventually rejects a request
   // instead of hanging it forever. With max:1 the pool serializes requests and
@@ -20,11 +29,18 @@ const pool = new Pool({
 // Cache table columns so we can validate filters + order_by
 const columnCache = new Map<string, Set<string>>();
 
+// Single chokepoint for acquiring a client: surface a clear config error before
+// pg ever tries to DNS-resolve a bad host (e.g. the "base" fallback).
+async function connect() {
+  if (DB_URL_ERR) throw new Error(DB_URL_ERR);
+  return await pool.connect();
+}
+
 async function getColumns(table: string): Promise<Set<string>> {
   const cached = columnCache.get(table);
   if (cached) return cached;
 
-  const client = await pool.connect();
+  const client = await connect();
   try {
     const r = await client.query(
       `select column_name
@@ -98,7 +114,7 @@ function safeLimit(limit?: number) {
 }
 
 async function run<T = any>(fn: (client: any) => Promise<T>): Promise<T> {
-  const client = await pool.connect();
+  const client = await connect();
   try {
     return await fn(client);
   } finally {

--- a/main.ts
+++ b/main.ts
@@ -49,9 +49,15 @@ import {
   recordSampleValuation,
 } from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
+import { databaseUrlError, getDatabaseUrl } from "./core/db-url.ts";
+
+// Cleaned once (repairs stray quotes/whitespace/`DATABASE_URL=` prefix that
+// would otherwise make pg resolve host "base"); see core/db-url.ts.
+const DB_URL = getDatabaseUrl();
+const DB_URL_ERR = DB_URL ? databaseUrlError(DB_URL) : "DATABASE_URL is not set";
 
 const pool = new Pool({
-  connectionString: Deno.env.get("DATABASE_URL"),
+  connectionString: DB_URL ?? undefined,
   max: 1,
   // connectionTimeoutMillis >= statement_timeout so a request queued behind an
   // in-flight query isn't killed before that query frees the single (max:1)
@@ -60,11 +66,21 @@ const pool = new Pool({
   connectionTimeoutMillis: 35_000,
 });
 
+// Guarded client acquisition (the debug routes connect directly): throw the
+// config error before pg tries to DNS-resolve a bad host like "base".
+async function poolConnect() {
+  if (DB_URL_ERR) throw new Error(DB_URL_ERR);
+  return await pool.connect();
+}
+
 // Thin-client mode: with no local DATABASE_URL (e.g. the compiled desktop
 // binary on a kiosk), proxy /api/* to the central deployment instead of a local
 // DB — no DB credentials on-device, one shared source of truth. Override the
 // upstream with THIRSTY_API.
-const REMOTE_API = Deno.env.get("DATABASE_URL")
+// A present-but-malformed DATABASE_URL stays in local-DB mode (so we don't
+// proxy thirsty.store → thirsty.store and loop) and surfaces DB_URL_ERR; only a
+// genuinely absent/blank value falls back to the proxy.
+const REMOTE_API = DB_URL
   ? null
   : (Deno.env.get("THIRSTY_API") || "https://thirsty.store").replace(/\/+$/, "");
 
@@ -91,19 +107,22 @@ const MAX_GELF_MESSAGE_SIZE = 8000;
 const TABLES = ["bundles", "inventory_transactions", "samples"] as const;
 
 function redactedDbUrl() {
-  const raw = Deno.env.get("DATABASE_URL");
-  if (!raw) return null;
+  // Report the CLEANED value (what pg actually sees) plus any validation error,
+  // so /__debug agrees with the pool instead of masking a "base"-host config.
+  if (!DB_URL) return null;
+  const error = DB_URL_ERR;
 
   try {
-    const u = new URL(raw);
+    const u = new URL(DB_URL);
     return {
       host: u.hostname,
       database: u.pathname.replace(/^\//, ""),
       user: u.username || null,
       hasPassword: Boolean(u.password),
+      ...(error ? { valid: false, error } : { valid: true }),
     };
   } catch {
-    return { parseError: true };
+    return { parseError: true, ...(error ? { error } : {}) };
   }
 }
 
@@ -828,7 +847,7 @@ export async function legacyHandler(req: Request): Promise<Response> {
 
   // DB debug
   if (pathname === "/__dbdebug") {
-    const client = await pool.connect();
+    const client = await poolConnect();
     try {
       const meta = await client.query(`
         select
@@ -859,7 +878,7 @@ export async function legacyHandler(req: Request): Promise<Response> {
     const expected = Deno.env.get("DEBUG_TOKEN");
     if (!expected || !token || token !== expected) return new Response("forbidden", { status: 403 });
 
-    const client = await pool.connect();
+    const client = await poolConnect();
     try {
       const counts: Record<string, number> = {};
       for (const t of TABLES) {


### PR DESCRIPTION
## Problem

`thirsty.store` was returning `500 getaddrinfo ENOTFOUND base` from every `/api/*` call:

```
Error: getaddrinfo ENOTFOUND base
    at .../pg-pool/3.10.1/index.js:45:11
    at async getColumns (file:///app/src/db.ts:27:18)
    at async listTable (file:///app/src/db.ts:118:16)
    at async legacyHandler (file:///app/src/main.ts:906:15)
```

`base` isn't our DB host — it's a fallback baked into `pg-connection-string` (the parser `pg` uses), which resolves the connection string against a dummy base URL `postgres://base`. **Any `DATABASE_URL` not recognized as an absolute `postgres://` URL keeps that host**, so pg tries to DNS-resolve a host literally named `base`.

Reproduced triggers (all real env-UI paste mistakes):

| `DATABASE_URL` value | host pg sees |
|---|---|
| `" postgres://…"` (leading space) | **base** ❌ |
| `'"postgres://…"'` (wrapped in quotes) | **base** ❌ |
| `DATABASE_URL=postgres://…` (whole `KEY=VALUE` pasted) | **base** ❌ |
| bare hostname / wrong scheme | **base** ❌ |
| clean `postgres://…` | correct host ✅ |

The root cause is a malformed `DATABASE_URL` value on the Deno Deploy project — but the code degraded to a cryptic DNS error instead of saying so.

## Fix

- **`core/db-url.ts`** (new):
  - `getDatabaseUrl()` — repairs the common mistakes: trims whitespace, strips one layer of wrapping quotes, drops a leading `DATABASE_URL=`/`:` prefix. Returns `null` when unset or blank.
  - `databaseUrlError()` — returns a human-readable reason for anything still not a `postgres://`/`postgresql://` URL (or a `/socket` path). Returns a string rather than throwing, so module init stays non-blocking (preserving the boot-resilience from #92).
- **`db.ts` / `main.ts`** — feed the cleaned value into `new Pool(...)`, and gate client acquisition (`connect()` / `poolConnect()`) so a bad config throws an actionable error **before** pg attempts the `base` DNS lookup.
- **Thin-client behavior preserved** — blank/unset still falls back to proxy mode; a present-but-malformed value stays local (so we don't proxy `thirsty.store → thirsty.store`).
- **`/__debug`** now reports the cleaned value plus `valid`/`error`, so it agrees with what the pool actually uses.

### Practical upshot

Redeploying auto-recovers the site if the cause is a stray space / quotes / prefix (the likely culprits). If the value is genuinely wrong (typo'd host or scheme), `/__debug` and the API now return a clear message instead of `ENOTFOUND base`.

> [!NOTE]
> This hardens the code path. If the live value is malformed in a way that can't be auto-repaired, the `DATABASE_URL` env var in the Deno Deploy dashboard still needs correcting.

## Tests

`core/db-url_test.ts` — 13 cases (repair, rejection, proxy fallback). `deno test core/db-url_test.ts` → **13 passed**. `deno check db.ts main.ts core/db-url.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)