### PR TITLE
Add eBay resale pricing formula + Demos/E2E demo

### DIFF
--- a/Demos/E2E/README.md
+++ b/Demos/E2E/README.md
@@ -1,0 +1,97 @@
+# Demos/E2E — eBay pricing formula
+
+A pricing formula for eBay resale listings that **undercuts the competition** and
+**moves product fast**, with an inviolable **fee-aware floor** so we never
+knowingly list at a loss.
+
+We resell TikTok Shop *free samples* on eBay: a creator gets a free sample, makes
+content, then we list the physical unit. This formula turns what we know about a
+product into a recommended Buy-It-Now price.
+
+- **Engine (source of truth):** [`core/ebay-pricing.ts`](../../core/ebay-pricing.ts) — pure, deterministic, unit-tested (`core/ebay-pricing_test.ts`).
+- **API:** `GET|POST /api/ebay-price` (add `?ladder=1` for the velocity walk-down).
+- **CLI demo:** [`ebay-pricing-demo.ts`](./ebay-pricing-demo.ts) — walks the scenario battery and prints a report.
+- **Visual demo:** [`ebay-pricing.html`](./ebay-pricing.html) — interactive, served at `/demos/ebay-pricing`.
+
+It replaces the old naive `Math.round(retail * 0.8)` the showcase used to guess a price.
+
+## Run it
+
+```bash
+# CLI (deterministic, no network needed):
+deno task demo:ebay-pricing
+# …or directly, with the raw JSON results:
+deno run -A Demos/E2E/ebay-pricing-demo.ts --json
+# …and end-to-end against a real TikTok Shop product:
+deno task demo:ebay-pricing -- --live 1729587769570529799
+
+# Visual (interactive): start the app, then open the page
+deno task start                       # local server (needs DATABASE_URL for the rest of the app)
+# → http://localhost:8000/demos/ebay-pricing
+```
+
+The visual page calls the same `/api/ebay-price` endpoint that runs the same
+`core/ebay-pricing.ts` engine as the CLI — one implementation, two surfaces.
+
+## The formula (STEP 0..9)
+
+A fixed pipeline, run top to bottom. Every input is sanitized first, so it never
+throws, never divides by zero, and never returns `NaN` or a below-floor price.
+
+0. **Sanitize** — coerce every input to a finite, sane value; clamp `feePct` into
+   `[0, 0.9]` so the gross-up denominator `(1 − feePct)` can never be ≤ 0.
+1. **Anchor to the market** — from the *cleaned* comps: drop retail-relative
+   absurd values, trim the top outliers, and lift a lone lowball to
+   `median × 0.5` so one predatory comp can't drag us to a loss. The cheapest
+   surviving credible comp is the anchor. No comps → `retail × 0.30` (the resale
+   band). No retail either → the fee floor drives the price.
+2. **Undercut** — price `max(anchorPct, anchorAbs)` below the anchor so ours is
+   the cheapest credible Buy-It-Now (gentler for a single comp; skipped when
+   anchoring off the retail fraction, which already sits below market).
+3. **Velocity markdown** — a staged, **monotonically non-increasing** multiplier
+   keyed to `daysListed` that walks the price down as the unit sits and saturates
+   so it never runs away:
+
+   | days | 0–6 | 7–13 | 14–20 | 21–29 | 30+ |
+   |------|-----|------|-------|-------|-----|
+   | ×    |1.00 |0.93  |0.85   |0.75   |0.65 |
+
+4. **Fee-aware floor (the load-bearing clamp)** — the smallest gross price whose
+   net still clears cost + margin after eBay's fee:
+
+   ```
+   floor = (costBasis + max(minMarginAbs, costBasis·minMarginPct) + shipping + fixedFee) / (1 − feePct)
+   ```
+
+   The floor **always wins** over the undercut and the markdown: `price = max(candidate, floor)`.
+5. **Ceiling** — `retail × 0.95` (new) / `0.80` (used) so we never meet or beat
+   true retail. If cost is so high that `floor > ceiling`, the floor wins and an
+   `unprofitableBelowRetail` flag is raised for human review.
+6. **Charm rounding** — round **down** to the nearest `.99` to preserve the
+   undercut. When no `.99` rung sits between the floor and the candidate (a
+   floor-bound listing), we ship the exact floor-respecting price rather than
+   charming **up** past the anchor — so rounding never breaches the floor, never
+   overshoots the market, and never makes an aging unit's price tick back up.
+
+The result carries diagnostics — `floor`, `ceiling`, `anchor`, `anchorSource`,
+`ageFactor`, `floorHit`, `unprofitableBelowRetail`, `lowConfidence`, `netAtPrice`,
+`undercutFromAnchor`, and a one-line `explanation`.
+
+## Guarantees (enforced by the tests)
+
+- **Never at a loss:** `price ≥ floor` and `netAtPrice ≥ minMarginAbs` (minus a rounding cent) for every input.
+- **Move fast:** re-pricing the same unit on a later day is always `≤` the earlier day's price (monotonic in age), bounded below by the floor.
+- **Undercut:** with real comps we land strictly below the cheapest credible comp — unless the market has fallen below our break-even, in which case the floor holds and `floorHit` says so.
+- **Never crashes:** garbage inputs (NaN, negatives, junk strings, `feePct ≥ 1`) are sanitized; the price is always finite and ≥ a hard minimum.
+
+## Tunable
+
+Everything is an optional parameter with a sensible default (see
+`DEFAULT_EBAY_PRICING`). A few worth knowing:
+
+- `minMarginAbs` (default `$3`) — minimum net profit. Set to `0` for a pure
+  fee-break-even liquidation profile.
+- `undercutPct` / `undercutAbs` — how far below the cheapest comp to sit.
+- `markdownSchedule` — the velocity ladder. Pass a custom `[[day, factor], …]`
+  (or `{day: factor}`) for a fire-sale or a patient profile; it's re-sanitized to
+  stay monotonic and floor-bounded.

--- a/Demos/E2E/ebay-pricing-demo.ts
+++ b/Demos/E2E/ebay-pricing-demo.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env -S deno run -A
+// Demos/E2E — eBay pricing formula, end-to-end.
+//
+// Walks the pricing engine (core/ebay-pricing.ts) through a battery of real-world
+// resale scenarios and prints, per scenario: the market anchor, the undercut, the
+// fee-aware floor, the retail ceiling, the recommended Buy-It-Now price, the net
+// after fees, and WHY. It then shows the velocity "walk-down" — the same unit
+// re-priced as it ages, so you can watch the ask step toward the floor.
+//
+// This is the deterministic, offline demo of the formula (no network needed).
+// Pass --live <productId ...> to ALSO hydrate a real TikTok Shop product from the
+// data-pimp catalog and price it end-to-end.
+//
+// Usage:
+//   deno run -A Demos/E2E/ebay-pricing-demo.ts
+//   deno task demo:ebay-pricing
+//   deno task demo:ebay-pricing -- --live 1729587769570529799
+//   deno run -A Demos/E2E/ebay-pricing-demo.ts --json        # machine-readable
+//
+// Flags:
+//   --live <id ...>   hydrate real product(s) via GET /api/product-lookup/:id and price them
+//   --api <url>       API base for --live (default https://thirsty.store)
+//   --json            print the raw EbayPriceResult objects as JSON instead of the report
+
+import {
+  computeEbayPrice,
+  type EbayPriceInput,
+  type EbayPriceResult,
+  markdownLadder,
+} from "../../core/ebay-pricing.ts";
+
+// ---- tiny arg parse (mirrors scripts/sample-e2e.ts) -----------------------
+function parseArgs(argv: string[]) {
+  const o: Record<string, string | boolean> = {};
+  const ids: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if ((key === "api") && next && !next.startsWith("--")) { o[key] = next; i++; }
+      else o[key] = true;
+    } else ids.push(a);
+  }
+  return { o, ids };
+}
+const { o, ids } = parseArgs(Deno.args);
+// Guard against `--api` with no value (parseArgs would set it to boolean true) —
+// fall back to the default rather than fetching from the literal "true".
+const API = String(typeof o.api === "string" ? o.api : "https://thirsty.store").replace(/\/+$/, "");
+const AS_JSON = Boolean(o.json);
+const LIVE = Boolean(o.live);
+
+const usd = (n: number) => "$" + n.toFixed(2);
+const pad = (s: string, n: number) => (s.length >= n ? s : s + " ".repeat(n - s.length));
+
+// ---- scenario battery (the reference matrix + a few lifelike cases) --------
+type Scenario = { title: string; note: string; input: EbayPriceInput };
+const SCENARIOS: Scenario[] = [
+  {
+    title: "Hot item, 3 comps, fresh",
+    note: "Ninja-style air fryer; undercut the cheapest credible comp",
+    input: { retail: 89.99, costBasis: 0, comps: [58, 62, 65], daysListed: 0 },
+  },
+  {
+    title: "Same item, aged 16 days",
+    note: "velocity markdown kicks in — price walks down",
+    input: { retail: 89.99, costBasis: 0, comps: [58, 62, 65], daysListed: 16 },
+  },
+  {
+    title: "No comps, retail only",
+    note: "anchor off the retail resale band (30%), no extra undercut",
+    input: { retail: 45, costBasis: 0, comps: [], daysListed: 0 },
+  },
+  {
+    title: "Single (noisy) comp",
+    note: "one observation → gentle undercut, low confidence",
+    input: { retail: 30, costBasis: 0, comps: [21.5], daysListed: 0 },
+  },
+  {
+    title: "Market collapsed below break-even",
+    note: "comps under our fee floor → floor wins, we won't list at a loss",
+    input: { retail: 12, costBasis: 0, comps: [4.0, 4.5], daysListed: 25 },
+  },
+  {
+    title: "Lowball outlier among good comps",
+    note: "a predatory $5 comp is lifted by the median guard",
+    input: { retail: 30, costBasis: 0, comps: [5, 22, 23, 24], condition: "used", daysListed: 40 },
+  },
+  {
+    title: "Agency bulk lot ($8 cost), used, old, no comps",
+    note: "floor-driven; still clears the $3 margin on the $8 cost",
+    input: { costBasis: 8, comps: [], condition: "used", daysListed: 40 },
+  },
+  {
+    title: "Bad buy: cost basis above retail ceiling",
+    note: "floor > ceiling → flagged unprofitable-below-retail for review",
+    input: { retail: 12, costBasis: 15, comps: [9, 11], daysListed: 0 },
+  },
+];
+
+function flags(r: EbayPriceResult): string {
+  const f: string[] = [];
+  if (r.floorHit) f.push("FLOOR");
+  if (r.unprofitableBelowRetail) f.push("⚠ UNPROFITABLE<RETAIL");
+  if (r.lowConfidence) f.push("low-confidence");
+  return f.length ? f.join(" · ") : "—";
+}
+
+function renderScenario(title: string, note: string, r: EbayPriceResult) {
+  const anchor = r.anchor === null ? "—" : usd(r.anchor);
+  const under = r.undercutFromAnchor === null
+    ? "—"
+    : (r.undercutFromAnchor >= 0 ? `-${usd(r.undercutFromAnchor)}` : `+${usd(-r.undercutFromAnchor)}`);
+  console.log(`\n▶ ${title}`);
+  console.log(`  ${note}`);
+  console.log(
+    `  anchor ${pad(anchor, 8)} (${pad(r.anchorSource, 6)})  ` +
+      `floor ${pad(usd(r.floor), 8)}  ceiling ${pad(usd(r.ceiling), 8)}  ` +
+      `age ${pad(String(r.daysListed) + "d", 5)} ×${r.ageFactor.toFixed(2)}`,
+  );
+  console.log(
+    `  \x1b[1m→ ${pad(usd(r.price), 9)}\x1b[0m  vs anchor ${pad(under, 9)}  ` +
+      `net ${pad(usd(r.netAtPrice), 8)}  [${flags(r)}]`,
+  );
+  console.log(`  ${r.explanation}`);
+}
+
+function renderLadder(input: EbayPriceInput) {
+  const rows = markdownLadder(input);
+  console.log("\n────────────────────────────────────────────────────────");
+  console.log("Velocity walk-down (same unit, priced as it ages):");
+  console.log(
+    "  " + pad("day", 6) + pad("factor", 8) + pad("price", 10) + "stage",
+  );
+  for (const row of rows) {
+    console.log(
+      "  " + pad(String(row.day) + "d", 6) + pad("×" + row.factor.toFixed(2), 8) +
+        pad(usd(row.price), 10) + (row.floorHit ? "\x1b[33m" : "") +
+        row.stage + (row.floorHit ? " (floor)\x1b[0m" : ""),
+    );
+  }
+}
+
+async function hydrate(id: string): Promise<EbayPriceInput & { name: string } | null> {
+  try {
+    const r = await fetch(`${API}/api/product-lookup/${encodeURIComponent(id)}`, {
+      headers: { accept: "application/json" },
+    });
+    if (!r.ok) return null;
+    const j = await r.json() as Record<string, unknown>;
+    const price = Number(j.price);
+    return {
+      name: String(j.name || id),
+      retail: Number.isFinite(price) && price > 0 ? price : undefined,
+      costBasis: 0,
+      comps: [],
+      daysListed: 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---- run -------------------------------------------------------------------
+if (AS_JSON) {
+  const out = SCENARIOS.map((s) => ({ ...s, result: computeEbayPrice(s.input) }));
+  console.log(JSON.stringify(out, null, 2));
+  Deno.exit(0);
+}
+
+console.log("╔══════════════════════════════════════════════════════════════╗");
+console.log("║  eBay pricing formula · Demos/E2E                              ║");
+console.log("║  undercut the competition · move product fast · never at a loss ║");
+console.log("╚══════════════════════════════════════════════════════════════╝");
+console.log(
+  "\nDefaults: eBay fee 13.25% + $0.30 · min net margin $3 · charm .99 · " +
+    "markdown 0/7/14/21/30d → 1.00/0.93/0.85/0.75/0.65",
+);
+
+for (const s of SCENARIOS) {
+  renderScenario(s.title, s.note, computeEbayPrice(s.input));
+}
+
+// Show the walk-down for the hot-item scenario.
+renderLadder({ retail: 89.99, costBasis: 0, comps: [58, 62, 65] });
+
+if (LIVE) {
+  const liveIds = ids.length ? ids : ["1729587769570529799"];
+  console.log("\n────────────────────────────────────────────────────────");
+  console.log(`Live hydrate → price (via ${API}/api/product-lookup):`);
+  for (const id of liveIds) {
+    const h = await hydrate(id);
+    if (!h) {
+      console.log(`\n▶ ${id} — could not hydrate (offline or unknown id)`);
+      continue;
+    }
+    const { name, ...input } = h;
+    if (!input.retail) {
+      console.log(`\n▶ ${name} [${id}] — unpriced product; formula falls back to the fee floor`);
+    }
+    renderScenario(`${name} [${id}]`, "live TikTok Shop product (no eBay comps → retail-anchored)", computeEbayPrice(input));
+  }
+}
+
+console.log("\n✓ demo complete. Try the visual version at /demos/ebay-pricing\n");
+Deno.exit(0);

--- a/Demos/E2E/ebay-pricing.html
+++ b/Demos/E2E/ebay-pricing.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>eBay Pricing Formula · Demos/E2E</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #070a12; --card: #11151f; --border: #1d2433; --fg: #eef1f6; --muted: #9aa6bd;
+      --orange: #fb923c; --green: #22c55e; --sky: #38bdf8; --gold: #ffe27a; --red: #f87171;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; }
+    body {
+      font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(120% 120% at 80% -10%, #131a2b, var(--bg) 60%); color: var(--fg);
+      padding: 22px 20px 40px;
+    }
+    a { color: var(--sky); }
+    .head { max-width: 1080px; margin: 0 auto 18px; }
+    .head h1 { margin: 0 0 4px; font-size: 22px; display: flex; align-items: center; gap: 10px; }
+    .head .logo { font-weight: 800; letter-spacing: -.5px; }
+    .head .logo .e{color:#e53238}.head .logo .b{color:#0064d2}.head .logo .a{color:#f5af02}.head .logo .y{color:#86b817}
+    .head p { margin: 0; color: var(--muted); font-size: 13px; }
+    .status { font-size: 12px; color: var(--muted); margin-top: 6px; }
+    .status b { color: var(--gold); }
+
+    .wrap { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 340px 1fr; gap: 18px; }
+    @media (max-width: 820px) { .wrap { grid-template-columns: 1fr; } }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 18px; }
+    .card h2 { margin: 0 0 14px; font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); font-weight: 700; }
+
+    .fld { margin-bottom: 15px; }
+    .fld label { display: flex; justify-content: space-between; font-size: 12px; color: var(--muted); margin-bottom: 5px; }
+    .fld label b { color: var(--fg); font-variant-numeric: tabular-nums; }
+    .fld input[type=range] { width: 100%; accent-color: var(--orange); }
+    .fld input[type=text], .fld input[type=number], .fld select {
+      width: 100%; background: #0c111b; border: 1px solid var(--border); border-radius: 8px;
+      padding: 8px 10px; color: var(--fg); font-size: 13px;
+    }
+    .seg { display: flex; gap: 6px; }
+    .seg button { flex: 1; background: #0c111b; border: 1px solid var(--border); color: var(--muted);
+      border-radius: 8px; padding: 8px; font-size: 13px; cursor: pointer; }
+    .seg button.on { border-color: var(--orange); color: var(--fg); background: #17110b; }
+    .presets { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+    .presets button { background: #0c111b; border: 1px solid var(--border); color: var(--sky);
+      border-radius: 999px; padding: 5px 11px; font-size: 12px; cursor: pointer; }
+    .presets button:hover { border-color: var(--sky); }
+
+    /* headline result */
+    .price { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+    .price .big { font-size: 46px; font-weight: 800; color: var(--gold); font-variant-numeric: tabular-nums;
+      text-shadow: 0 0 24px rgba(255,210,80,.25); }
+    .price .pill { font-size: 12px; font-weight: 700; padding: 4px 10px; border-radius: 999px; border: 1px solid; }
+    .pill.floor { color: var(--red); border-color: #7d2f2f; }
+    .pill.warn { color: var(--orange); border-color: #7d5a2f; }
+    .pill.low { color: var(--sky); border-color: #24566c; }
+    .pill.ok { color: var(--green); border-color: #2f7d4f; }
+    .explain { color: var(--muted); font-size: 13px; margin: 10px 0 0; }
+    .explain b { color: var(--fg); }
+
+    .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 16px 0 4px; }
+    @media (max-width: 560px) { .metrics { grid-template-columns: repeat(2, 1fr); } }
+    .metric { background: #0c111b; border: 1px solid var(--border); border-radius: 10px; padding: 9px 11px; }
+    .metric .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
+    .metric .v { font-weight: 700; font-size: 16px; margin-top: 2px; font-variant-numeric: tabular-nums; }
+
+    /* price map */
+    .map { margin: 20px 0 6px; }
+    .map .track { position: relative; height: 54px; margin: 26px 6px 30px; border-radius: 8px;
+      background: linear-gradient(90deg, #1a1f2c, #10141d); border: 1px solid var(--border); }
+    .mk { position: absolute; top: 0; bottom: 0; width: 2px; transform: translateX(-1px); }
+    .mk .cap { position: absolute; left: 50%; transform: translateX(-50%); white-space: nowrap; font-size: 11px; }
+    .mk .cap.top { top: -22px; } .mk .cap.bot { bottom: -24px; }
+    .mk.floor { background: var(--red); } .mk.floor .cap { color: var(--red); }
+    .mk.ceiling { background: var(--green); } .mk.ceiling .cap { color: var(--green); }
+    .mk.comp { background: var(--sky); } .mk.comp .cap { color: var(--sky); }
+    .mk.retail { background: #6b7280; } .mk.retail .cap { color: #9aa3af; }
+    .mk.price { background: var(--gold); width: 4px; box-shadow: 0 0 12px rgba(255,210,80,.6); }
+    .mk.price .cap { color: var(--gold); font-weight: 800; font-size: 13px; }
+    .mk.dot .cap.bot { display: none; }
+    .band { position: absolute; top: 0; bottom: 0; background: rgba(56,189,248,.10); border-left: 1px dashed rgba(56,189,248,.4);
+      border-right: 1px dashed rgba(56,189,248,.4); }
+    .band .lab { position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%); font-size: 11px; color: var(--sky); white-space: nowrap; }
+
+    /* ladder */
+    .ladder { display: flex; align-items: flex-end; gap: 10px; height: 150px; margin: 14px 4px 6px; }
+    .rung { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 6px; height: 100%; justify-content: flex-end; }
+    .rung .bar { width: 100%; border-radius: 6px 6px 0 0; background: linear-gradient(180deg, var(--orange), #b45309); min-height: 3px;
+      transition: height .3s ease; position: relative; }
+    .rung.floorhit .bar { background: linear-gradient(180deg, var(--red), #7f1d1d); }
+    .rung .bar .p { position: absolute; top: -18px; left: 50%; transform: translateX(-50%); font-size: 11px; color: var(--fg);
+      font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .rung .d { font-size: 11px; color: var(--muted); }
+    .foot { max-width: 1080px; margin: 18px auto 0; color: var(--muted); font-size: 12px; }
+    .foot code { color: var(--sky); background: #0c1320; border: 1px solid #1d2c40; border-radius: 5px; padding: 1px 6px; }
+  </style>
+</head>
+<body>
+  <div class="head">
+    <h1><span class="logo"><span class="e">e</span><span class="b">B</span><span class="a">a</span><span class="y">y</span></span> Pricing Formula <span style="color:var(--muted);font-size:14px;font-weight:400">· Demos/E2E</span></h1>
+    <p>Undercut the competition · move product fast · a fee-aware floor so we never list at a loss.</p>
+    <div class="status" id="status">computing…</div>
+  </div>
+
+  <div class="wrap">
+    <div class="card">
+      <h2>Inputs</h2>
+
+      <div class="presets" id="presets"></div>
+
+      <div class="fld" style="margin-top:14px">
+        <label>Retail / MSRP <b id="retail-v">$89.99</b></label>
+        <input type="range" id="retail" min="0" max="300" step="1" value="90" />
+      </div>
+      <div class="fld">
+        <label>Cost basis <b id="cost-v">$0</b></label>
+        <input type="range" id="cost" min="0" max="60" step="1" value="0" />
+      </div>
+      <div class="fld">
+        <label>Competitor prices (comps, comma-separated)</label>
+        <input type="text" id="comps" value="58, 62, 65" placeholder="e.g. 58, 62, 65 (blank = none)" />
+      </div>
+      <div class="fld">
+        <label>Condition</label>
+        <div class="seg" id="cond">
+          <button data-v="new" class="on">New / sealed</button>
+          <button data-v="used">Used</button>
+        </div>
+      </div>
+      <div class="fld">
+        <label>Days listed (age) <b id="days-v">0d</b></label>
+        <input type="range" id="days" min="0" max="45" step="1" value="0" />
+      </div>
+      <div class="fld">
+        <label>Min net margin <b id="margin-v">$3</b></label>
+        <input type="range" id="margin" min="0" max="20" step="0.5" value="3" />
+      </div>
+      <div class="fld">
+        <label>eBay fee <b id="fee-v">13.25%</b></label>
+        <input type="range" id="fee" min="0" max="25" step="0.25" value="13.25" />
+      </div>
+      <div class="fld">
+        <label>Undercut <b id="under-v">5%</b></label>
+        <input type="range" id="under" min="0" max="25" step="1" value="5" />
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Recommended eBay Buy-It-Now</h2>
+      <div class="price">
+        <div class="big" id="big">$—</div>
+        <span id="pills"></span>
+      </div>
+      <p class="explain" id="explain">—</p>
+
+      <div class="metrics">
+        <div class="metric"><div class="k">Floor (break-even)</div><div class="v" id="m-floor">$—</div></div>
+        <div class="metric"><div class="k">Anchor</div><div class="v" id="m-anchor">$—</div></div>
+        <div class="metric"><div class="k">Ceiling</div><div class="v" id="m-ceiling">$—</div></div>
+        <div class="metric"><div class="k">Net profit</div><div class="v" id="m-net">$—</div></div>
+      </div>
+
+      <div class="map">
+        <h2 style="margin-top:14px">Price map</h2>
+        <div class="track" id="track"></div>
+      </div>
+
+      <h2>Velocity walk-down (price as the unit ages)</h2>
+      <div class="ladder" id="ladder"></div>
+    </div>
+  </div>
+
+  <div class="foot">
+    One implementation, two surfaces: this page calls <code>GET /api/ebay-price?…&amp;ladder=1</code>, which runs the same
+    <code>core/ebay-pricing.ts</code> engine as the CLI demo (<code>deno task demo:ebay-pricing</code>). See
+    <code>Demos/E2E/README.md</code>.
+  </div>
+
+  <script>
+    "use strict";
+    var $ = function (id) { return document.getElementById(id); };
+    var usd = function (n) { return n == null ? "$—" : "$" + Number(n).toFixed(2); };
+    var esc = function (s) { return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]; }); };
+
+    // Resolve an API base that works whether the page is served by data-pimp
+    // (same-origin) or opened standalone (fall back to production).
+    var BASES = (location.protocol === "http:" || location.protocol === "https:")
+      ? [location.origin, "https://thirsty.store"]
+      : ["https://thirsty.store"];
+    var apiBase = BASES[0];
+
+    var condition = "new";
+    $("cond").addEventListener("click", function (e) {
+      var b = e.target.closest("button"); if (!b) return;
+      condition = b.dataset.v;
+      [].forEach.call($("cond").children, function (c) { c.classList.toggle("on", c === b); });
+      schedule();
+    });
+
+    var PRESETS = [
+      { label: "🔥 Hot item + comps", retail: 90, cost: 0, comps: "58, 62, 65", cond: "new", days: 0, margin: 3, fee: 13.25, under: 5 },
+      { label: "🕗 Aged 21 days", retail: 90, cost: 0, comps: "58, 62, 65", cond: "new", days: 21, margin: 3, fee: 13.25, under: 5 },
+      { label: "❓ No comps", retail: 45, cost: 0, comps: "", cond: "new", days: 0, margin: 3, fee: 13.25, under: 5 },
+      { label: "📉 Market below floor", retail: 12, cost: 0, comps: "4, 4.5", cond: "new", days: 25, margin: 3, fee: 13.25, under: 5 },
+      { label: "🎯 Lowball outlier", retail: 30, cost: 0, comps: "5, 22, 23, 24", cond: "used", days: 40, margin: 3, fee: 13.25, under: 5 },
+      { label: "📦 Agency lot", retail: 0, cost: 8, comps: "", cond: "used", days: 40, margin: 3, fee: 13.25, under: 5 },
+    ];
+    var pbox = $("presets");
+    PRESETS.forEach(function (p) {
+      var b = document.createElement("button"); b.textContent = p.label;
+      b.onclick = function () { applyPreset(p); };
+      pbox.appendChild(b);
+    });
+    function applyPreset(p) {
+      $("retail").value = p.retail; $("cost").value = p.cost; $("comps").value = p.comps;
+      $("days").value = p.days; $("margin").value = p.margin; $("fee").value = p.fee; $("under").value = p.under;
+      condition = p.cond;
+      [].forEach.call($("cond").children, function (c) { c.classList.toggle("on", c.dataset.v === p.cond); });
+      sync(); schedule();
+    }
+
+    function sync() {
+      $("retail-v").textContent = Number($("retail").value) > 0 ? usd($("retail").value) : "none";
+      $("cost-v").textContent = "$" + $("cost").value;
+      $("days-v").textContent = $("days").value + "d";
+      $("margin-v").textContent = "$" + $("margin").value;
+      $("fee-v").textContent = Number($("fee").value).toFixed(2) + "%";
+      $("under-v").textContent = $("under").value + "%";
+    }
+    ["retail", "cost", "comps", "days", "margin", "fee", "under"].forEach(function (id) {
+      $(id).addEventListener("input", function () { sync(); schedule(); });
+    });
+
+    function buildInput() {
+      var retail = Number($("retail").value);
+      var comps = $("comps").value.split(",").map(function (s) { return s.trim(); }).filter(Boolean);
+      return {
+        retail: retail > 0 ? retail : undefined,
+        costBasis: Number($("cost").value),
+        comps: comps,
+        condition: condition,
+        daysListed: Number($("days").value),
+        minMarginAbs: Number($("margin").value),
+        feePct: Number($("fee").value) / 100,
+        undercutPct: Number($("under").value) / 100,
+        ladder: true,
+      };
+    }
+
+    var timer = null;
+    function schedule() { clearTimeout(timer); timer = setTimeout(run, 120); }
+
+    async function fetchPrice(input) {
+      var lastErr;
+      for (var i = 0; i < BASES.length; i++) {
+        try {
+          var r = await fetch(BASES[i] + "/api/ebay-price", {
+            method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input),
+          });
+          if (r.ok) { apiBase = BASES[i]; return await r.json(); }
+          lastErr = "HTTP " + r.status;
+        } catch (e) { lastErr = e && e.message || String(e); }
+      }
+      throw new Error(lastErr || "unreachable");
+    }
+
+    async function run() {
+      var input = buildInput();
+      try {
+        var res = await fetchPrice(input);
+        render(input, res);
+        $("status").innerHTML = "live · <b>" + esc(apiBase) + "/api/ebay-price</b>";
+      } catch (e) {
+        $("status").innerHTML = "⚠ API unreachable (" + esc(e.message) +
+          ") — start data-pimp (<b>deno task start</b>) or open via <b>/demos/ebay-pricing</b>.";
+      }
+    }
+
+    function render(input, r) {
+      $("big").textContent = usd(r.price);
+      $("explain").innerHTML = esc(r.explanation);
+      $("m-floor").textContent = usd(r.floor);
+      $("m-anchor").textContent = r.anchor == null ? "—" : usd(r.anchor) + " (" + esc(r.anchorSource) + ")";
+      $("m-ceiling").textContent = usd(r.ceiling);
+      $("m-net").textContent = usd(r.netAtPrice);
+
+      var pills = [];
+      if (r.floorHit) pills.push('<span class="pill floor">floor holds</span>');
+      if (r.unprofitableBelowRetail) pills.push('<span class="pill warn">⚠ below-retail loss risk</span>');
+      if (r.lowConfidence) pills.push('<span class="pill low">single comp</span>');
+      if (!r.floorHit && r.anchorSource === "comp") {
+        pills.push('<span class="pill ok">undercuts market by ' + usd(r.undercutFromAnchor) + '</span>');
+      }
+      if (r.ageFactor < 1) pills.push('<span class="pill low">−' + Math.round((1 - r.ageFactor) * 100) + '% aged</span>');
+      $("pills").innerHTML = pills.join(" ");
+
+      renderMap(input, r);
+      renderLadder(r.ladder || []);
+    }
+
+    function renderMap(input, r) {
+      var comps = (input.comps || []).map(Number).filter(function (n) { return n > 0; });
+      var cheapest = comps.length ? Math.min.apply(null, comps) : null;
+      var pts = [r.price, r.floor, r.ceiling, cheapest, input.retail].filter(function (n) { return n != null && isFinite(n); });
+      var max = Math.max.apply(null, pts) * 1.12 || 10;
+      var track = $("track"); track.innerHTML = "";
+      var pos = function (v) { return Math.max(0, Math.min(100, (v / max) * 100)); };
+
+      // undercut band between recommended price and cheapest comp
+      if (cheapest != null && r.price < cheapest) {
+        var band = document.createElement("div"); band.className = "band";
+        var a = pos(r.price), b = pos(cheapest);
+        band.style.left = a + "%"; band.style.width = (b - a) + "%";
+        band.innerHTML = '<span class="lab">undercut</span>';
+        track.appendChild(band);
+      }
+      function mark(v, cls, capTop, capBot, dot) {
+        if (v == null || !isFinite(v)) return;
+        var el = document.createElement("div"); el.className = "mk " + cls + (dot ? " dot" : "");
+        el.style.left = pos(v) + "%";
+        el.innerHTML = (capTop ? '<span class="cap top">' + capTop + "</span>" : "") +
+          (capBot ? '<span class="cap bot">' + capBot + "</span>" : "");
+        track.appendChild(el);
+      }
+      mark(input.retail, "retail", null, input.retail ? "retail " + usd(input.retail) : null, true);
+      mark(r.ceiling, "ceiling", "ceiling " + usd(r.ceiling), null);
+      mark(cheapest, "comp", "cheapest comp " + usd(cheapest), null);
+      mark(r.floor, "floor", null, "floor " + usd(r.floor));
+      mark(r.price, "price", "YOU " + usd(r.price), null);
+    }
+
+    function renderLadder(rows) {
+      var box = $("ladder"); box.innerHTML = "";
+      if (!rows.length) return;
+      var max = Math.max.apply(null, rows.map(function (r) { return r.price; })) || 1;
+      rows.forEach(function (row) {
+        var d = document.createElement("div"); d.className = "rung" + (row.floorHit ? " floorhit" : "");
+        var h = Math.max(4, Math.round((row.price / max) * 100));
+        d.innerHTML = '<div class="bar" style="height:' + h + '%"><span class="p">' + usd(row.price) + '</span></div>' +
+          '<div class="d">' + row.day + "d</div>";
+        box.appendChild(d);
+      });
+    }
+
+    sync(); run();
+  </script>
+</body>
+</html>

--- a/core/ebay-pricing.ts
+++ b/core/ebay-pricing.ts
@@ -155,11 +155,16 @@ function round2(n: number): number {
 }
 
 // Finite number or undefined — the sanitize primitive. Strips "$"/"," so string
-// prices ("$25.00") coerce cleanly.
+// prices ("$25.00") coerce cleanly. A blank/empty string is treated as ABSENT
+// (undefined), not 0 — otherwise `?feePct=&minMarginAbs=` (empty params from a
+// serialized form) would read as 0 via Number(""), silently zeroing the fee and
+// margin and dropping the floor below its intended fee-aware value.
 function num(x: unknown): number | undefined {
   if (typeof x === "number") return Number.isFinite(x) ? x : undefined;
   if (typeof x === "string") {
-    const n = Number(x.replace(/[$,\s]/g, ""));
+    const t = x.replace(/[$,\s]/g, "");
+    if (t === "") return undefined;
+    const n = Number(t);
     return Number.isFinite(n) ? n : undefined;
   }
   return undefined;
@@ -263,7 +268,10 @@ export function resolveParams(input: EbayPriceInput = {}): EbayPricingParams {
     medianFloorFrac: Math.max(0, numOr(input.medianFloorFrac, DEFAULT_EBAY_PRICING.medianFloorFrac)),
     absurdHighMult: Math.max(1, numOr(input.absurdHighMult, DEFAULT_EBAY_PRICING.absurdHighMult)),
     absurdLowMult: Math.max(0, numOr(input.absurdLowMult, DEFAULT_EBAY_PRICING.absurdLowMult)),
-    usedMult: Math.max(0, numOr(input.usedMult, DEFAULT_EBAY_PRICING.usedMult)),
+    // Capped at 1: a used haircut only ever REDUCES the anchor — a value > 1
+    // would raise a comp anchor and could price us above the cheapest comp
+    // (same reasoning as the markdown-factor cap in normalizeSchedule).
+    usedMult: Math.min(1, Math.max(0, numOr(input.usedMult, DEFAULT_EBAY_PRICING.usedMult))),
     newCeilingRate: Math.max(0, numOr(input.newCeilingRate, DEFAULT_EBAY_PRICING.newCeilingRate)),
     usedCeilingRate: Math.max(0, numOr(input.usedCeilingRate, DEFAULT_EBAY_PRICING.usedCeilingRate)),
     noRetailCeilingMult: Math.max(1, numOr(input.noRetailCeilingMult, DEFAULT_EBAY_PRICING.noRetailCeilingMult)),

--- a/core/ebay-pricing.ts
+++ b/core/ebay-pricing.ts
@@ -1,0 +1,506 @@
+// eBay resale pricing formula — undercut the competition AND move product fast.
+//
+// We resell TikTok Shop *free product samples* on eBay: a creator gets a free
+// sample, makes content, then we list the physical unit. This module turns a
+// product (retail/MSRP, cost basis, observed competitor prices, condition, and
+// how long the unit has been sitting) into a recommended Buy-It-Now list price.
+//
+// Business priorities, in order:
+//   1. UNDERCUT — price just below the cheapest CREDIBLE competitor so ours is
+//      the most attractive Buy-It-Now.
+//   2. MOVE FAST — the longer a unit sits, the more aggressively we mark it down
+//      (dead inventory is dead money; cost basis is usually $0).
+//   3. NEVER knowingly list at a loss after eBay fees — an inviolable, fee-aware
+//      floor wins over both the undercut and the age markdown.
+//
+// It replaces the old naive `Math.round(retail * 0.8)` used by the E2E showcase.
+//
+// The engine is a pure, deterministic 10-step pipeline (STEP 0..9). It never
+// throws and never returns NaN: every input is sanitized, divide-by-zero is
+// guarded (1 - feePct is clamped > 0.1), and the final price is guaranteed
+// finite, >= a hard minimum, >= the fee floor, and net-positive vs the target.
+//
+// The fee-net identity matches the sold flow in core/lifecycle.ts:
+//   net = salePrice - fees - shipping - costBasis,  fees = salePrice*feePct + fixedFee
+// so the floor computed here is consistent with what the resale event records.
+
+export type EbayCondition = "new" | "used";
+
+// One [dayThreshold, multiplier] rung of the velocity markdown ladder.
+export type MarkdownRung = [day: number, factor: number];
+
+export type EbayPriceInput = {
+  // Market inputs
+  retail?: number | string; // MSRP / min_sku_original_price — anchor ceiling
+  costBasis?: number | string; // what we paid; 0 for free samples
+  comps?: Array<number | string> | null; // observed competitor prices
+  condition?: string; // "new" (default, sealed samples) | "used"
+  daysListed?: number | string; // age of the unit → velocity markdown
+
+  // Fee model
+  feePct?: number | string; // eBay final value fee fraction (default 0.1325)
+  fixedFee?: number | string; // per-order fixed fee $ (default 0.30)
+  shipping?: number | string; // seller-borne shipping $ (default 0)
+
+  // Floor / margin
+  minMarginAbs?: number | string; // min NET profit $ (default 3.00)
+  minMarginPct?: number | string; // min net margin vs costBasis (default 0)
+  minListPrice?: number | string; // hard viability floor $ (default 1.00)
+
+  // Anchor / undercut
+  retailAnchorRate?: number | string; // no-comp anchor = retail*this (default 0.30)
+  undercutPct?: number | string; // multi-comp undercut fraction (default 0.05)
+  undercutAbs?: number | string; // multi-comp undercut floor $ (default 1.00)
+  gentleUndercutPct?: number | string; // single-comp undercut fraction (default 0.03)
+  gentleUndercutAbs?: number | string; // single-comp undercut floor $ (default 0.50)
+
+  // Comp cleaning
+  trimFrac?: number | string; // top fraction trimmed as outliers (default 0.10)
+  medianFloorFrac?: number | string; // lone-lowball lift threshold (default 0.50)
+  absurdHighMult?: number | string; // drop comps > retail*this (default 1.5)
+  absurdLowMult?: number | string; // drop comps < retail*this (default 0.05)
+
+  // Condition / ceiling / rounding
+  usedMult?: number | string; // anchor haircut for used (default 0.85)
+  newCeilingRate?: number | string; // ceiling = retail*this, new (default 0.95)
+  usedCeilingRate?: number | string; // ceiling = retail*this, used (default 0.80)
+  noRetailCeilingMult?: number | string; // ceiling = floor*this w/o retail (default 3.0)
+  charmCents?: number | string; // charm target cents (default 0.99)
+
+  // Velocity ladder — [dayThreshold, factor] rungs, or a {day: factor} map.
+  markdownSchedule?: MarkdownRung[] | Record<string, number> | null;
+};
+
+export type EbayPriceResult = {
+  price: number; // the recommended Buy-It-Now list price
+  floor: number; // fee-aware break-even+margin floor (never priced below)
+  ceiling: number; // upper clamp (retail-derived, or floor*mult w/o retail)
+  anchor: number | null; // the reference we undercut from (null if floor-driven)
+  anchorSource: "comp" | "retail" | "floor";
+  ageFactor: number; // velocity multiplier applied for the current age
+  floorHit: boolean; // the floor bound the price (market/age would've gone lower)
+  unprofitableBelowRetail: boolean; // costBasis so high floor > retail ceiling
+  lowConfidence: boolean; // exactly one comp — softer undercut used
+  netAtPrice: number; // net after fees+shipping+cost at the recommended price
+  stage: string; // human label for the current age bucket
+  condition: EbayCondition;
+  daysListed: number;
+  compsUsed: number; // credible comps after cleaning
+  undercutFromAnchor: number | null; // $ below the anchor (null if floor-driven)
+  explanation: string; // one-line human summary
+};
+
+export type EbayPricingParams = {
+  feePct: number;
+  fixedFee: number;
+  shipping: number;
+  minMarginAbs: number;
+  minMarginPct: number;
+  minListPrice: number;
+  retailAnchorRate: number;
+  undercutPct: number;
+  undercutAbs: number;
+  gentleUndercutPct: number;
+  gentleUndercutAbs: number;
+  trimFrac: number;
+  medianFloorFrac: number;
+  absurdHighMult: number;
+  absurdLowMult: number;
+  usedMult: number;
+  newCeilingRate: number;
+  usedCeilingRate: number;
+  noRetailCeilingMult: number;
+  charmCents: number;
+  markdownSchedule: MarkdownRung[];
+};
+
+// The default velocity ladder: day 0-6 full price, then a weekly step-down that
+// saturates at 35% off for 30+ days. Factors are monotonically non-increasing so
+// the recommended price only ever walks DOWN as a unit ages, and it never runs
+// away past the terminal rung (or below the fee floor).
+export const DEFAULT_MARKDOWN_SCHEDULE: MarkdownRung[] = [
+  [0, 1.0],
+  [7, 0.93],
+  [14, 0.85],
+  [21, 0.75],
+  [30, 0.65],
+];
+
+export const DEFAULT_EBAY_PRICING: EbayPricingParams = {
+  feePct: 0.1325,
+  fixedFee: 0.30,
+  shipping: 0,
+  minMarginAbs: 3.0,
+  minMarginPct: 0,
+  minListPrice: 1.0,
+  retailAnchorRate: 0.30,
+  undercutPct: 0.05,
+  undercutAbs: 1.0,
+  gentleUndercutPct: 0.03,
+  gentleUndercutAbs: 0.50,
+  trimFrac: 0.10,
+  medianFloorFrac: 0.50,
+  absurdHighMult: 1.5,
+  absurdLowMult: 0.05,
+  usedMult: 0.85,
+  newCeilingRate: 0.95,
+  usedCeilingRate: 0.80,
+  noRetailCeilingMult: 3.0,
+  charmCents: 0.99,
+  markdownSchedule: DEFAULT_MARKDOWN_SCHEDULE,
+};
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// Finite number or undefined — the sanitize primitive. Strips "$"/"," so string
+// prices ("$25.00") coerce cleanly.
+function num(x: unknown): number | undefined {
+  if (typeof x === "number") return Number.isFinite(x) ? x : undefined;
+  if (typeof x === "string") {
+    const n = Number(x.replace(/[$,\s]/g, ""));
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+// Finite number with a default (used for tunables that must always resolve).
+function numOr(x: unknown, d: number): number {
+  const n = num(x);
+  return n === undefined ? d : n;
+}
+
+function median(sorted: number[]): number {
+  const n = sorted.length;
+  if (n === 0) return NaN;
+  const mid = n >> 1;
+  return n % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// Normalize a schedule (array of rungs or {day: factor} map) into sorted,
+// sanitized rungs: finite day>=0, factor>0, enforced monotonically non-increasing
+// (running-min) so the "only ever walks down" guarantee holds even for a
+// caller-supplied ladder. Falls back to the default if nothing usable survives.
+function normalizeSchedule(
+  input: MarkdownRung[] | Record<string, number> | null | undefined,
+): MarkdownRung[] {
+  let rungs: MarkdownRung[] = [];
+  if (Array.isArray(input)) {
+    rungs = input
+      .map((r) => [num(r?.[0]), num(r?.[1])] as [number | undefined, number | undefined])
+      .filter((r): r is MarkdownRung => r[0] !== undefined && r[1] !== undefined);
+  } else if (input && typeof input === "object") {
+    rungs = Object.entries(input)
+      .map(([k, v]) => [num(k), num(v)] as [number | undefined, number | undefined])
+      .filter((r): r is MarkdownRung => r[0] !== undefined && r[1] !== undefined);
+  }
+  rungs = rungs
+    .filter(([day, factor]) => day >= 0 && factor > 0)
+    .sort((a, b) => a[0] - b[0]);
+  if (!rungs.length) return DEFAULT_MARKDOWN_SCHEDULE;
+  // A velocity ladder only ever marks DOWN: cap every factor at 1.0 (so a
+  // caller-supplied rung > 1 can't inflate the price above the anchor) and
+  // enforce non-increasing factors via a running minimum.
+  let prev = 1;
+  return rungs.map(([day, factor]) => {
+    const f = Math.min(factor, prev);
+    prev = f;
+    return [day, f] as MarkdownRung;
+  });
+}
+
+// The velocity multiplier for a given age: the factor of the highest dayThreshold
+// <= age, or 1.00 when the unit is younger than every threshold. Non-increasing
+// in age by construction (schedule is sorted + running-min normalized).
+function markdownFactor(age: number, schedule: MarkdownRung[]): number {
+  let factor = 1.0;
+  for (const [day, f] of schedule) {
+    if (day <= age) factor = f;
+    else break;
+  }
+  return factor;
+}
+
+// Human label for the current age bucket, derived from the schedule rungs so a
+// custom ladder still gets sensible stage names.
+function stageLabel(age: number, schedule: MarkdownRung[]): string {
+  // Find the active rung and the next one (if any).
+  let activeIdx = -1;
+  for (let i = 0; i < schedule.length; i++) {
+    if (schedule[i][0] <= age) activeIdx = i;
+    else break;
+  }
+  if (activeIdx < 0) {
+    const first = schedule[0]?.[0] ?? 0;
+    return `fresh (0-${Math.max(0, first - 1)}d)`;
+  }
+  const start = schedule[activeIdx][0];
+  const next = schedule[activeIdx + 1]?.[0];
+  const off = Math.round((1 - schedule[activeIdx][1]) * 100);
+  const range = next === undefined ? `${start}d+` : `${start}-${next - 1}d`;
+  const label = activeIdx === 0 ? "fresh" : off >= 30 ? "clearance" : "aging";
+  return off > 0 ? `${label} (${range}, -${off}%)` : `${label} (${range})`;
+}
+
+// Load the effective params for a run, applying defaults and clamping the fee
+// fraction so the gross-up denominator (1 - feePct) can never be <= 0.
+export function resolveParams(input: EbayPriceInput = {}): EbayPricingParams {
+  const feePct = Math.min(0.9, Math.max(0, numOr(input.feePct, DEFAULT_EBAY_PRICING.feePct)));
+  return {
+    feePct,
+    fixedFee: Math.max(0, numOr(input.fixedFee, DEFAULT_EBAY_PRICING.fixedFee)),
+    shipping: Math.max(0, numOr(input.shipping, DEFAULT_EBAY_PRICING.shipping)),
+    minMarginAbs: Math.max(0, numOr(input.minMarginAbs, DEFAULT_EBAY_PRICING.minMarginAbs)),
+    minMarginPct: Math.max(0, numOr(input.minMarginPct, DEFAULT_EBAY_PRICING.minMarginPct)),
+    minListPrice: Math.max(0.01, numOr(input.minListPrice, DEFAULT_EBAY_PRICING.minListPrice)),
+    retailAnchorRate: Math.max(0, numOr(input.retailAnchorRate, DEFAULT_EBAY_PRICING.retailAnchorRate)),
+    undercutPct: Math.max(0, numOr(input.undercutPct, DEFAULT_EBAY_PRICING.undercutPct)),
+    undercutAbs: Math.max(0, numOr(input.undercutAbs, DEFAULT_EBAY_PRICING.undercutAbs)),
+    gentleUndercutPct: Math.max(0, numOr(input.gentleUndercutPct, DEFAULT_EBAY_PRICING.gentleUndercutPct)),
+    gentleUndercutAbs: Math.max(0, numOr(input.gentleUndercutAbs, DEFAULT_EBAY_PRICING.gentleUndercutAbs)),
+    trimFrac: Math.min(0.9, Math.max(0, numOr(input.trimFrac, DEFAULT_EBAY_PRICING.trimFrac))),
+    medianFloorFrac: Math.max(0, numOr(input.medianFloorFrac, DEFAULT_EBAY_PRICING.medianFloorFrac)),
+    absurdHighMult: Math.max(1, numOr(input.absurdHighMult, DEFAULT_EBAY_PRICING.absurdHighMult)),
+    absurdLowMult: Math.max(0, numOr(input.absurdLowMult, DEFAULT_EBAY_PRICING.absurdLowMult)),
+    usedMult: Math.max(0, numOr(input.usedMult, DEFAULT_EBAY_PRICING.usedMult)),
+    newCeilingRate: Math.max(0, numOr(input.newCeilingRate, DEFAULT_EBAY_PRICING.newCeilingRate)),
+    usedCeilingRate: Math.max(0, numOr(input.usedCeilingRate, DEFAULT_EBAY_PRICING.usedCeilingRate)),
+    noRetailCeilingMult: Math.max(1, numOr(input.noRetailCeilingMult, DEFAULT_EBAY_PRICING.noRetailCeilingMult)),
+    charmCents: Math.min(0.99, Math.max(0, numOr(input.charmCents, DEFAULT_EBAY_PRICING.charmCents))),
+    markdownSchedule: normalizeSchedule(input.markdownSchedule),
+  };
+}
+
+/**
+ * Compute the recommended eBay Buy-It-Now price for a resale unit.
+ *
+ * Pure and deterministic — see the STEP 0..9 pipeline below, which mirrors the
+ * documented formula. Returns the price plus diagnostics (floor, ceiling, anchor,
+ * why the floor/ceiling bound it, projected net) for UI/audit.
+ */
+export function computeEbayPrice(input: EbayPriceInput = {}): EbayPriceResult {
+  const p = resolveParams(input);
+
+  // ---- STEP 0 — SANITIZE ---------------------------------------------------
+  const retailRaw = num(input.retail);
+  const retail = retailRaw !== undefined && retailRaw > 0 ? retailRaw : undefined;
+  const costBasis = (() => {
+    const c = num(input.costBasis);
+    return c !== undefined && c > 0 ? c : 0;
+  })();
+  const condition: EbayCondition = String(input.condition ?? "").toLowerCase() === "used"
+    ? "used"
+    : "new";
+  const daysListed = (() => {
+    const d = num(input.daysListed);
+    return d !== undefined && d > 0 ? Math.floor(d) : 0;
+  })();
+  let comps = (Array.isArray(input.comps) ? input.comps : [])
+    .map(num)
+    .filter((c): c is number => c !== undefined && c > 0);
+
+  // ---- STEP 1a — CLEAN COMPS FOR OUTLIERS ----------------------------------
+  if (retail !== undefined) {
+    const hi = retail * p.absurdHighMult;
+    const lo = retail * p.absurdLowMult;
+    comps = comps.filter((c) => c <= hi && c >= lo);
+  }
+  const C = comps.slice().sort((a, b) => a - b);
+  const n = C.length;
+
+  // ---- STEP 1b — ROBUST COMP ANCHOR ----------------------------------------
+  let compAnchor: number | undefined;
+  let lowConfidence = false;
+  if (n === 1) {
+    compAnchor = C[0];
+    lowConfidence = true;
+  } else if (n >= 2) {
+    const k = Math.min(Math.ceil(p.trimFrac * n), n - 1); // trim top outliers, keep >=1
+    const trimmed = C.slice(0, n - k);
+    const lowCredible = trimmed[0];
+    const med = median(trimmed);
+    compAnchor = lowCredible < med * p.medianFloorFrac
+      ? med * p.medianFloorFrac // lift a lone lowball so it can't drag us to a loss
+      : lowCredible;
+  }
+
+  // ---- STEP 2 — BASE ANCHOR + FALLBACK CHAIN -------------------------------
+  let baseAnchor: number | undefined;
+  let anchorSource: "comp" | "retail" | "floor";
+  if (compAnchor !== undefined) {
+    baseAnchor = compAnchor;
+    anchorSource = "comp";
+  } else if (retail !== undefined) {
+    baseAnchor = retail * p.retailAnchorRate;
+    anchorSource = "retail";
+  } else {
+    baseAnchor = undefined;
+    anchorSource = "floor";
+  }
+
+  // The market reference we price against (cheapest credible comp, or the retail
+  // resale anchor) BEFORE the condition haircut — this is what we report as the
+  // anchor and undercut from, since the used haircut is our own adjustment, not
+  // the competition's price.
+  const marketAnchor = baseAnchor;
+
+  // ---- STEP 3 — CONDITION HAIRCUT ------------------------------------------
+  if (condition === "used" && baseAnchor !== undefined) {
+    baseAnchor = baseAnchor * p.usedMult;
+  }
+
+  // ---- STEP 4 — UNDERCUT ---------------------------------------------------
+  let priceAfterUndercut: number | undefined;
+  if (anchorSource === "comp" && baseAnchor !== undefined) {
+    const pct = lowConfidence ? p.gentleUndercutPct : p.undercutPct;
+    const abs = lowConfidence ? p.gentleUndercutAbs : p.undercutAbs;
+    const undercut = Math.max(baseAnchor * pct, abs);
+    priceAfterUndercut = baseAnchor - undercut;
+  } else if (anchorSource === "retail" && baseAnchor !== undefined) {
+    priceAfterUndercut = baseAnchor; // retail*rate already sits below market
+  } else {
+    priceAfterUndercut = undefined; // floor-driven
+  }
+
+  // ---- STEP 5 — VELOCITY MARKDOWN ------------------------------------------
+  const ageFactor = markdownFactor(daysListed, p.markdownSchedule);
+  const priceAfterVelocity = priceAfterUndercut !== undefined
+    ? priceAfterUndercut * ageFactor
+    : undefined;
+
+  // ---- STEP 6 — FEE-AWARE FLOOR (the load-bearing clamp) --------------------
+  const requiredNet = costBasis + Math.max(p.minMarginAbs, costBasis * p.minMarginPct);
+  const floorRaw = (requiredNet + p.shipping + p.fixedFee) / (1 - p.feePct);
+  const absoluteFloor = round2(Math.max(floorRaw, p.minListPrice));
+  let candidate = priceAfterVelocity !== undefined
+    ? Math.max(priceAfterVelocity, absoluteFloor)
+    : absoluteFloor;
+  const floorHit = priceAfterVelocity === undefined || priceAfterVelocity < absoluteFloor;
+
+  // ---- STEP 7 — CEILING ----------------------------------------------------
+  let ceiling: number;
+  let unprofitableBelowRetail = false;
+  if (retail !== undefined) {
+    const ceilingRate = condition === "used" ? p.usedCeilingRate : p.newCeilingRate;
+    ceiling = round2(retail * ceilingRate);
+    if (ceiling < absoluteFloor) {
+      // Cost basis so high we can't sell under retail without a loss — floor
+      // wins, and we surface the conflict for human review.
+      candidate = absoluteFloor;
+      unprofitableBelowRetail = true;
+    } else if (candidate > ceiling) {
+      candidate = ceiling;
+    }
+  } else {
+    ceiling = round2(absoluteFloor * p.noRetailCeilingMult);
+    candidate = Math.max(Math.min(candidate, ceiling), absoluteFloor);
+  }
+
+  // ---- STEP 8 — CHARM ROUNDING (down to the nearest .99, floor-safe) --------
+  // Round DOWN to the nearest charm price so the ask stays at/below the computed
+  // undercut. If the largest charm rung ≤ candidate would breach the floor, there
+  // is no charm price in [floor, candidate]; rather than charm UP to the next .99
+  // — which would overshoot the anchor (breaking the undercut) or jump the ask UP
+  // as the unit ages (breaking monotonicity) — we list at the exact
+  // floor-respecting `candidate` (always ≥ floor). Floor-bound listings therefore
+  // show the precise break-even+margin price instead of a charm .99.
+  const base = Math.floor(candidate);
+  let charmDown = base + p.charmCents;
+  if (charmDown > candidate) charmDown = (base - 1) + p.charmCents;
+  let preFinal = charmDown >= absoluteFloor ? charmDown : candidate;
+  if (preFinal > ceiling && ceiling >= absoluteFloor) preFinal = ceiling;
+  let finalPrice = round2(preFinal);
+
+  // ---- STEP 9 — FINAL SAFETY + ASSEMBLE ------------------------------------
+  if (!Number.isFinite(finalPrice) || finalPrice < absoluteFloor) {
+    finalPrice = round2(Math.max(absoluteFloor, p.minListPrice));
+  }
+  const netAtPrice = round2(finalPrice * (1 - p.feePct) - p.fixedFee - p.shipping - costBasis);
+
+  return {
+    price: finalPrice,
+    floor: absoluteFloor,
+    ceiling,
+    anchor: marketAnchor !== undefined ? round2(marketAnchor) : null,
+    anchorSource,
+    ageFactor,
+    floorHit,
+    unprofitableBelowRetail,
+    lowConfidence,
+    netAtPrice,
+    stage: stageLabel(daysListed, p.markdownSchedule),
+    condition,
+    daysListed,
+    compsUsed: n,
+    // Gap to the market anchor we referenced. Positive = we're below it
+    // (undercutting); negative = the floor forced us above the market (won't
+    // sell at a loss); null = no anchor (floor-driven, no comps and no retail).
+    undercutFromAnchor: marketAnchor === undefined ? null : round2(marketAnchor - finalPrice),
+    explanation: explain({
+      anchorSource,
+      baseAnchor: marketAnchor,
+      finalPrice,
+      floorHit,
+      unprofitableBelowRetail,
+      lowConfidence,
+      ageFactor,
+      condition,
+      daysListed,
+    }),
+  };
+}
+
+function explain(o: {
+  anchorSource: "comp" | "retail" | "floor";
+  baseAnchor: number | undefined; // the market anchor (pre-haircut)
+  finalPrice: number;
+  floorHit: boolean;
+  unprofitableBelowRetail: boolean;
+  lowConfidence: boolean;
+  ageFactor: number;
+  condition: EbayCondition;
+  daysListed: number;
+}): string {
+  const parts: string[] = [];
+  const anchor = o.baseAnchor;
+  // Did we actually land below the market anchor (true undercut), or did the
+  // floor force us at/above it (market is below our break-even)?
+  const undercutting = anchor !== undefined && o.finalPrice < anchor;
+  if (o.anchorSource === "comp") {
+    const which = o.lowConfidence ? "a single comp" : "the cheapest credible comp";
+    const at = anchor !== undefined ? ` (~$${round2(anchor).toFixed(2)})` : "";
+    parts.push(undercutting ? `undercut ${which}${at}` : `${which}${at} is below our break-even`);
+  } else if (o.anchorSource === "retail") {
+    parts.push("no comps — anchored off the retail resale band");
+  } else {
+    parts.push("no comps or retail — driven by the fee-aware floor");
+  }
+  // The used haircut only bites when there is an anchor to haircut.
+  if (o.condition === "used" && o.anchorSource !== "floor") parts.push("used haircut applied");
+  if (o.daysListed > 0 && o.ageFactor < 1) {
+    parts.push(`aged ${o.daysListed}d → ${Math.round((1 - o.ageFactor) * 100)}% velocity markdown`);
+  }
+  if (o.floorHit) parts.push("held at the break-even floor (won't list at a loss)");
+  if (o.unprofitableBelowRetail) parts.push("⚠ floor exceeds retail ceiling — bad cost basis");
+  return `$${o.finalPrice.toFixed(2)}: ${parts.join(", ")}.`;
+}
+
+// Preview the full velocity walk-down for a unit: the recommended price at each
+// schedule rung (holding market inputs fixed). Powers the Demos/E2E markdown
+// ladder — you can watch the ask step down toward the floor as days pass.
+export type MarkdownLadderRow = {
+  day: number;
+  factor: number;
+  price: number;
+  floorHit: boolean;
+  stage: string;
+};
+
+export function markdownLadder(input: EbayPriceInput = {}): MarkdownLadderRow[] {
+  const schedule = normalizeSchedule(input.markdownSchedule);
+  return schedule.map(([day]) => {
+    const r = computeEbayPrice({ ...input, daysListed: day });
+    return { day, factor: r.ageFactor, price: r.price, floorHit: r.floorHit, stage: r.stage };
+  });
+}

--- a/core/ebay-pricing_test.ts
+++ b/core/ebay-pricing_test.ts
@@ -258,6 +258,37 @@ Deno.test("a velocity schedule rung > 1 is capped so the ladder only marks DOWN"
   expect(r.price).toBeLessThan(25); // still undercuts the cheapest credible comp
 });
 
+Deno.test("blank numeric strings are treated as absent, not 0 (defaults hold)", () => {
+  // A serialized form / query string can send empty optional fields. These must
+  // fall back to the defaults (fee 13.25%, margin $3), not coerce to 0 and drop
+  // the floor below its intended fee-aware value.
+  const blank = computeEbayPrice({
+    retail: 40,
+    costBasis: 20,
+    comps: [25, 28, 30],
+    feePct: "" as unknown as number,
+    minMarginAbs: "" as unknown as number,
+    fixedFee: "" as unknown as number,
+  });
+  const defaulted = computeEbayPrice({ retail: 40, costBasis: 20, comps: [25, 28, 30] });
+  expect(blank.floor).toBe(defaulted.floor); // ~ (20+3+0.30)/0.8675 = 26.86
+  expect(blank.floor).toBeGreaterThan(26); // NOT the 20.30 a zeroed fee/margin gives
+  expect(blank.price).toBe(defaulted.price);
+  expect(blank.netAtPrice).toBeGreaterThanOrEqual(3);
+});
+
+Deno.test("a used haircut > 1 is capped so it cannot raise a comp anchor above the market", () => {
+  const r = computeEbayPrice({
+    retail: 40,
+    costBasis: 0,
+    comps: [25, 28, 30],
+    condition: "used",
+    usedMult: 1.5, // supposed haircut, tuned wrong
+  });
+  expect(r.floorHit).toBe(false);
+  expect(r.price).toBeLessThan(25); // still undercuts the cheapest credible comp
+});
+
 Deno.test("custom fire-sale schedule is honored and stays floor-bounded", () => {
   const r30 = computeEbayPrice({
     retail: 50,

--- a/core/ebay-pricing_test.ts
+++ b/core/ebay-pricing_test.ts
@@ -1,0 +1,270 @@
+import { expect } from "@std/expect";
+import {
+  computeEbayPrice,
+  DEFAULT_MARKDOWN_SCHEDULE,
+  type EbayPriceInput,
+  markdownLadder,
+} from "./ebay-pricing.ts";
+
+// ---------------------------------------------------------------------------
+// Reference test matrix (T1..T8) from the design synthesis. Each case has a
+// hand-worked expected output; see the STEP 0..9 pipeline in ebay-pricing.ts.
+// ---------------------------------------------------------------------------
+
+Deno.test("T1 — multi-comp, fresh, new: undercuts the cheapest credible comp", () => {
+  const r = computeEbayPrice({ retail: 40, costBasis: 0, comps: [25, 28, 30], daysListed: 0 });
+  expect(r.floor).toBe(3.8);
+  expect(r.anchor).toBe(25); // top comp (30) trimmed; median guard passes → 25
+  expect(r.anchorSource).toBe("comp");
+  expect(r.price).toBe(22.99); // 25 - 1.25 undercut → 23.75 → charm down 22.99
+  expect(r.floorHit).toBe(false);
+  expect(r.price).toBeLessThan(25); // strictly undercuts the cheapest comp
+  expect(r.netAtPrice).toBeGreaterThan(3); // clears the $3 target net
+});
+
+Deno.test("T2 — same unit aged 16d prices strictly below the fresh price (monotonic)", () => {
+  const base: EbayPriceInput = { retail: 40, costBasis: 0, comps: [25, 28, 30] };
+  const fresh = computeEbayPrice({ ...base, daysListed: 0 });
+  const aged = computeEbayPrice({ ...base, daysListed: 16 });
+  expect(aged.ageFactor).toBe(0.85);
+  expect(aged.price).toBe(19.99);
+  expect(aged.price).toBeLessThan(fresh.price);
+});
+
+Deno.test("T3 — market below break-even: floor wins, we don't list at a loss", () => {
+  const r = computeEbayPrice({ retail: 12, costBasis: 0, comps: [4.0, 4.5], daysListed: 25 });
+  expect(r.floor).toBe(3.8);
+  expect(r.floorHit).toBe(true);
+  expect(r.price).toBe(3.8); // floor-bound → exact break-even+margin floor (no charm-up)
+  expect(r.price).toBeGreaterThanOrEqual(r.floor);
+  expect(r.netAtPrice).toBeGreaterThanOrEqual(3);
+});
+
+Deno.test("T4 — agency lot, used, old, no comps, no retail: floor-driven", () => {
+  const r = computeEbayPrice({
+    costBasis: 8,
+    comps: [],
+    condition: "used",
+    daysListed: 40,
+    minMarginAbs: 3,
+  });
+  expect(r.anchorSource).toBe("floor");
+  expect(r.floor).toBe(13.03); // (8+3+0.30)/0.8675
+  expect(r.floorHit).toBe(true);
+  expect(r.price).toBe(13.03); // floor-driven → the exact floor
+  expect(r.unprofitableBelowRetail).toBe(false);
+  // netAtPrice is net PROFIT after cost — clears the $3 margin on top of the $8 cost.
+  expect(r.netAtPrice).toBeGreaterThanOrEqual(3);
+  // Gross retained (price - fees - shipping) covers cost + margin ($11).
+  expect(r.netAtPrice + 8).toBeGreaterThanOrEqual(11);
+});
+
+Deno.test("T5 — single lowball comp lifted by the median guard; used haircut", () => {
+  const r = computeEbayPrice({
+    retail: 30,
+    costBasis: 0,
+    comps: [5, 22, 24, 23],
+    condition: "used",
+    daysListed: 40,
+  });
+  expect(r.anchor).toBe(11); // lone $5 lowball lifted to median(5,22,23)*0.5 = 11
+  expect(r.ageFactor).toBe(0.65);
+  expect(r.price).toBe(4.99);
+  expect(r.floorHit).toBe(false);
+});
+
+Deno.test("T6 — cost basis so high the floor exceeds the retail ceiling", () => {
+  const r = computeEbayPrice({
+    retail: 12,
+    costBasis: 15,
+    comps: [9, 11],
+    daysListed: 0,
+    minMarginAbs: 3,
+  });
+  expect(r.floor).toBe(21.1); // (15+3+0.30)/0.8675
+  expect(r.floorHit).toBe(true);
+  expect(r.unprofitableBelowRetail).toBe(true);
+  expect(r.price).toBe(21.1); // floor overrides the retail ceiling
+  expect(r.price).toBeGreaterThan(12); // above retail — flagged for review
+});
+
+Deno.test("T7 — liquidation profile (minMarginAbs=0): floor collapses to minListPrice", () => {
+  const r = computeEbayPrice({
+    retail: 25,
+    costBasis: 0,
+    comps: [],
+    daysListed: 7,
+    minMarginAbs: 0,
+  });
+  expect(r.anchorSource).toBe("retail"); // no comps → retail*0.30
+  expect(r.floor).toBe(1.0); // (0+0.30)/0.8675 = 0.35 → max(_, minListPrice 1.00)
+  expect(r.ageFactor).toBe(0.93);
+  expect(r.price).toBe(5.99); // 25*0.30=7.50 → *0.93=6.975 → charm 5.99
+});
+
+Deno.test("T8 — fully degenerate inputs never crash and never go below floor/NaN", () => {
+  const r = computeEbayPrice({
+    retail: NaN,
+    costBasis: -5,
+    comps: [NaN, -3, 0, "x" as unknown as number, 18],
+    condition: "weird",
+    daysListed: -4,
+    feePct: 1.5, // clamped to 0.90 → (1-fee)=0.10
+  });
+  expect(Number.isFinite(r.price)).toBe(true);
+  expect(r.floor).toBe(33.0); // (3+0.30)/0.10
+  expect(r.floorHit).toBe(true);
+  expect(r.price).toBe(33.0); // floor-bound → the exact floor
+  expect(r.price).toBeGreaterThanOrEqual(r.floor);
+  expect(r.condition).toBe("new"); // "weird" → new
+  expect(r.daysListed).toBe(0); // negative → 0
+});
+
+// ---------------------------------------------------------------------------
+// Property / invariant tests — hold across a broad grid of inputs.
+// ---------------------------------------------------------------------------
+
+function* grid(): Generator<EbayPriceInput> {
+  const retails = [undefined, 5, 12, 40, 89.99, 250];
+  const costs = [0, 2, 8, 30];
+  const compSets = [[], [7], [9, 11], [25, 28, 30], [5, 22, 23, 24], [1, 2, 999]];
+  const conditions = ["new", "used"];
+  const ages = [0, 3, 7, 14, 21, 30, 120, 400];
+  for (const retail of retails) {
+    for (const costBasis of costs) {
+      for (const comps of compSets) {
+        for (const condition of conditions) {
+          for (const daysListed of ages) {
+            yield { retail, costBasis, comps, condition, daysListed };
+          }
+        }
+      }
+    }
+  }
+}
+
+Deno.test("invariant: price is always finite, >= floor, and net covers the target margin", () => {
+  for (const input of grid()) {
+    const r = computeEbayPrice(input);
+    expect(Number.isFinite(r.price)).toBe(true);
+    expect(r.price).toBeGreaterThanOrEqual(r.floor);
+    expect(r.price).toBeGreaterThan(0);
+    // Net at the recommended price must cover cost + the insisted margin
+    // (minus at most a rounding cent). Default minMarginAbs is 3.00.
+    expect(r.netAtPrice).toBeGreaterThanOrEqual(2.99);
+  }
+});
+
+Deno.test("invariant: velocity markdown is monotonically non-increasing in age", () => {
+  for (const base of grid()) {
+    let prev = Infinity;
+    for (const daysListed of [0, 7, 14, 21, 30, 90, 500]) {
+      const r = computeEbayPrice({ ...base, daysListed });
+      expect(r.price).toBeLessThanOrEqual(prev + 1e-9);
+      prev = r.price;
+    }
+  }
+});
+
+Deno.test("invariant: never priced above the ceiling unless the floor forces it", () => {
+  for (const input of grid()) {
+    const r = computeEbayPrice(input);
+    if (!r.unprofitableBelowRetail) {
+      expect(r.price).toBeLessThanOrEqual(r.ceiling + 1e-9);
+    } else {
+      // floor > ceiling: the floor wins and the flag is raised.
+      expect(r.price).toBeGreaterThanOrEqual(r.floor);
+    }
+  }
+});
+
+Deno.test("with real comps we either undercut the cheapest credible comp or hit the floor", () => {
+  // Broaden the grid with cost bases that push the floor to sit between charm
+  // rungs just under a comp — the exact shape that can defeat a naive charm.
+  const extra: EbayPriceInput[] = [
+    { comps: [9.88], costBasis: 4.75 },
+    { comps: [8.5], costBasis: 4 },
+    { retail: 20, comps: [6.2], costBasis: 3 },
+  ];
+  for (const input of [...grid(), ...extra]) {
+    const r = computeEbayPrice(input);
+    if (r.anchorSource === "comp" && r.anchor !== null) {
+      // When the floor doesn't bind, we MUST land strictly below the cheapest
+      // credible comp; when it binds we may sit at/above it (won't list at a loss).
+      if (!r.floorHit) expect(r.price).toBeLessThan(r.anchor);
+      else expect(r.price).toBeGreaterThanOrEqual(r.floor);
+    }
+  }
+});
+
+Deno.test("markdownLadder previews a non-increasing, floor-bounded price walk", () => {
+  const rows = markdownLadder({ retail: 60, costBasis: 0, comps: [30, 32, 35] });
+  expect(rows.length).toBe(DEFAULT_MARKDOWN_SCHEDULE.length);
+  expect(rows[0].day).toBe(0);
+  let prev = Infinity;
+  for (const row of rows) {
+    expect(row.price).toBeLessThanOrEqual(prev + 1e-9);
+    expect(row.price).toBeGreaterThan(0);
+    prev = row.price;
+  }
+});
+
+Deno.test("string/dollar-formatted inputs are coerced", () => {
+  const r = computeEbayPrice({
+    retail: "$40.00",
+    comps: ["$25", "28", "$30.00"],
+    daysListed: "0",
+  });
+  expect(r.price).toBe(22.99);
+});
+
+Deno.test("charm rounding: recommended prices end in .99 unless a hard cap intervenes", () => {
+  for (const input of grid()) {
+    const r = computeEbayPrice(input);
+    const cents = Math.round((r.price - Math.floor(r.price)) * 100);
+    const atCeiling = Math.abs(r.price - r.ceiling) < 1e-9;
+    // When the floor sits between two charm rungs and it did NOT bind, the exact
+    // undercut price (just above the floor) is kept rather than charmed above the
+    // anchor — allow that narrow floor band too.
+    const nextCharm = Math.ceil(r.floor - 0.99) + 0.99;
+    const inFloorBand = r.price >= r.floor - 1e-9 && r.price <= nextCharm + 1e-9;
+    expect(cents === 99 || atCeiling || inFloorBand).toBe(true);
+  }
+});
+
+Deno.test("single comp with no charm rung above the floor still undercuts (not above the comp)", () => {
+  // Regression: comps=[9.88], costBasis=4.75 → floor 9.28, undercut 9.38. The only
+  // charm rungs are 8.99 (below floor) and 9.99 (above the comp); we must keep the
+  // exact 9.38 rather than jump to 9.99 above the sole comp.
+  const r = computeEbayPrice({ comps: [9.88], costBasis: 4.75 });
+  expect(r.anchor).toBe(9.88);
+  expect(r.floorHit).toBe(false);
+  expect(r.price).toBeGreaterThanOrEqual(r.floor);
+  expect(r.price).toBeLessThan(9.88); // strictly undercuts the sole comp
+  expect(r.netAtPrice).toBeGreaterThanOrEqual(3);
+});
+
+Deno.test("a velocity schedule rung > 1 is capped so the ladder only marks DOWN", () => {
+  // A caller-supplied factor > 1 must not inflate the price above the anchor.
+  const r = computeEbayPrice({
+    retail: 40,
+    costBasis: 0,
+    comps: [25, 28, 30],
+    daysListed: 0,
+    markdownSchedule: [[0, 1.5]],
+  });
+  expect(r.ageFactor).toBeLessThanOrEqual(1);
+  expect(r.floorHit).toBe(false);
+  expect(r.price).toBeLessThan(25); // still undercuts the cheapest credible comp
+});
+
+Deno.test("custom fire-sale schedule is honored and stays floor-bounded", () => {
+  const r30 = computeEbayPrice({
+    retail: 50,
+    comps: [30],
+    daysListed: 30,
+    markdownSchedule: [[0, 1], [4, 0.85], [8, 0.7], [12, 0.55], [16, 0.45]],
+  });
+  expect(r30.ageFactor).toBe(0.45); // saturates at the terminal rung
+  expect(r30.price).toBeGreaterThanOrEqual(r30.floor);
+});

--- a/deno.json
+++ b/deno.json
@@ -33,11 +33,12 @@
     "sync:statuses": "deno run --allow-net --allow-read --allow-write --allow-env scripts/sync-statuses.ts",
     "seed:kiosk": "deno run -A scripts/seed-from-kiosk.ts",
     "e2e:samples": "deno run -A scripts/sample-e2e.ts",
+    "demo:ebay-pricing": "deno run -A Demos/E2E/ebay-pricing-demo.ts",
     "prune:dbs": "deno run -A scripts/prune-branch-dbs.ts",
     "member:build": "cd member && deno task build",
     "build": "deno task member:build",
-    "build:mac": "deno task member:build && deno compile -A --include static --include member/_fresh --target aarch64-apple-darwin --output build/data-pimp-mac-arm64 main.ts && deno compile -A --include static --include member/_fresh --target x86_64-apple-darwin --output build/data-pimp-mac-x64 main.ts",
-    "build:windows": "deno task member:build && deno compile -A --include static --include member/_fresh --target x86_64-pc-windows-msvc --output build/data-pimp-windows main.ts"
+    "build:mac": "deno task member:build && deno compile -A --include static --include Demos --include member/_fresh --target aarch64-apple-darwin --output build/data-pimp-mac-arm64 main.ts && deno compile -A --include static --include Demos --include member/_fresh --target x86_64-apple-darwin --output build/data-pimp-mac-x64 main.ts",
+    "build:windows": "deno task member:build && deno compile -A --include static --include Demos --include member/_fresh --target x86_64-pc-windows-msvc --output build/data-pimp-windows main.ts"
   },
   "deploy": {
     "org": "easierbycode",

--- a/main.ts
+++ b/main.ts
@@ -49,6 +49,11 @@ import {
   recordSampleValuation,
 } from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
+import {
+  computeEbayPrice,
+  type EbayPriceInput,
+  markdownLadder,
+} from "./core/ebay-pricing.ts";
 import { databaseUrlError, getDatabaseUrl } from "./core/db-url.ts";
 
 // Cleaned once (repairs stray quotes/whitespace/`DATABASE_URL=` prefix that
@@ -827,6 +832,13 @@ export async function legacyHandler(req: Request): Promise<Response> {
   if (pathname === "/e2e" || pathname === "/e2e.html") {
     return await serveLocalFile("./static/e2e.html", "text/html; charset=utf-8");
   }
+  // Demos/E2E — interactive eBay pricing-formula demo (undercut + move fast).
+  // Calls /api/ebay-price so the page and the server share one implementation.
+  if (
+    pathname === "/demos/ebay-pricing" || pathname === "/demos/ebay-pricing.html"
+  ) {
+    return await serveLocalFile("./Demos/E2E/ebay-pricing.html", "text/html; charset=utf-8");
+  }
   if (pathname === "/ui.js") {
     return await serveLocalFile("./static/ui.js", "text/javascript; charset=utf-8");
   }
@@ -1362,6 +1374,64 @@ export async function legacyHandler(req: Request): Promise<Response> {
 
       if (pathname === "/api/sample-valuation") {
         return json(await fetchSampleValuationWithEdits());
+      }
+
+      // eBay resale price recommendation — undercut the competition + move fast,
+      // fee-aware floor so we never list at a loss (see core/ebay-pricing.ts).
+      // Pure/stateless: no DB, no Graylog. GET with query params for a quick
+      // check, or POST a JSON body (comps as an array) for the full formula.
+      // ?ladder=1 (or body.ladder) also returns the velocity walk-down preview.
+      // CORS — called cross-origin by the Demos/E2E pricing demo.
+      if (pathname === "/api/ebay-price") {
+        if (req.method === "OPTIONS") return corsPreflight();
+        try {
+          const q = url.searchParams;
+          const body = (req.method === "POST" ? await readJsonBody(req) : {}) as Record<
+            string,
+            unknown
+          >;
+          // Coerce any picked value (body value or query string) to string | number
+          // | undefined — the formula parses "$25.00"-style strings itself.
+          const pick = (k: string): string | number | undefined => {
+            const v = body[k];
+            if (typeof v === "number" || typeof v === "string") return v;
+            if (v !== undefined && v !== null) return String(v);
+            const qv = q.get(k);
+            return qv === null ? undefined : qv;
+          };
+          // Comps: JSON body array, a comma-separated string body, or a
+          // comma-separated ?comps=25,28,30 query.
+          const comps: Array<string | number> = Array.isArray(body.comps)
+            ? (body.comps as unknown[]).map((x) => typeof x === "number" ? x : String(x))
+            : (typeof body.comps === "string" ? body.comps : (q.get("comps") || ""))
+              .split(",").map((s) => s.trim()).filter(Boolean);
+          const input: EbayPriceInput = {
+            retail: pick("retail"),
+            costBasis: pick("costBasis"),
+            comps,
+            condition: typeof pick("condition") === "string"
+              ? pick("condition") as string
+              : undefined,
+            daysListed: pick("daysListed"),
+            feePct: pick("feePct"),
+            fixedFee: pick("fixedFee"),
+            shipping: pick("shipping"),
+            minMarginAbs: pick("minMarginAbs"),
+            minMarginPct: pick("minMarginPct"),
+            undercutPct: pick("undercutPct"),
+            markdownSchedule: (body.markdownSchedule ?? undefined) as
+              EbayPriceInput["markdownSchedule"],
+          };
+          const result = computeEbayPrice(input);
+          const wantLadder = q.get("ladder") === "1" ||
+            (body as Record<string, unknown>).ladder === true;
+          return corsJson(wantLadder ? { ...result, ladder: markdownLadder(input) } : result);
+        } catch (error) {
+          return corsJson(
+            { ok: false, error: error instanceof Error ? error.message : String(error) },
+            400,
+          );
+        }
       }
 
       // Persist a valuation INSTANCE (all raw inputs) so it can be recomputed


### PR DESCRIPTION
## What & why

We resell TikTok Shop **free samples** on eBay. This adds a pricing formula that turns what we know about a unit — retail/MSRP, cost basis, competitor prices (comps), condition, and how long it's been sitting — into a recommended Buy‑It‑Now price that:

1. **Undercuts the competition** — prices just below the cheapest *credible* comp so ours is the most attractive BIN.
2. **Moves product fast** — a staged, monotonic markdown walks the price down the longer a unit sits (dead inventory is dead money).
3. **Never lists at a loss** — an inviolable, fee‑aware floor wins over both the undercut and the markdown.

It replaces the old naive `Math.round(retail * 0.8)` guess the E2E showcase used.

## The formula (`core/ebay-pricing.ts`)

A pure, deterministic 10‑step pipeline (STEP 0–9). It **never throws, never returns NaN, and never prices below the floor**:

- **Anchor** to the market: clean comps (drop absurd values, trim top outliers, lift a lone lowball to `median × 0.5`), take the cheapest credible comp; fall back to `retail × 0.30` (the 10/20/30% resale band), then to the fee floor.
- **Undercut** the anchor by `max(pct, abs)` (gentler for a single comp).
- **Velocity markdown** keyed to `daysListed` — `0/7/14/21/30d → 1.00/0.93/0.85/0.75/0.65` — monotonically non‑increasing and saturating so it never runs away.
- **Fee‑aware floor** by gross‑up: `floor = (costBasis + max(minMarginAbs, costBasis·minMarginPct) + shipping + fixedFee) / (1 − feePct)`, using the same `net = salePrice − fees − shipping − costBasis` identity as the sold flow in `core/lifecycle.ts`. `feePct` is clamped so the denominator can't hit 0.
- **Ceiling** at `retail × 0.95` (new) / `0.80` (used); if cost pushes `floor > ceiling`, the floor wins and an `unprofitableBelowRetail` flag is raised.
- **Charm rounding** down to `.99`; for a floor‑bound listing (no `.99` rung between floor and candidate) it ships the exact floor‑respecting price rather than charming *up* past the anchor — which keeps the undercut, the floor, and age‑monotonicity all intact.

Every result carries diagnostics (`floor`, `ceiling`, `anchor`, `anchorSource`, `ageFactor`, `floorHit`, `unprofitableBelowRetail`, `lowConfidence`, `netAtPrice`, `undercutFromAnchor`, and a one‑line `explanation`).

## Demos/E2E

- **CLI:** `deno task demo:ebay-pricing` — walks a scenario battery and prints a report + the velocity walk‑down; `--live <productId>` hydrates a real TikTok Shop product and prices it.
- **Visual:** `Demos/E2E/ebay-pricing.html`, served at **`/demos/ebay-pricing`** — interactive sliders, a price‑map showing floor / undercut / comp / ceiling, and the markdown ladder. It calls `/api/ebay-price`, so the page and the server run the *same* engine.
- **README** documents the formula and the guarantees.

## API

`GET|POST /api/ebay-price` (CORS, pure/stateless, `?ladder=1` for the walk‑down).

## How it was built & checked

The formula spec was synthesized from a 3‑approach design panel (profit‑floor / velocity / market‑anchored), then the diff went through an adversarial correctness review. The review surfaced four real defects — all fixed and regression‑tested:

- a caller‑supplied markdown rung `> 1` could mark the price *up* (now capped at 1.0);
- charm re‑clamp could push the ask above the sole comp while reporting `floorHit: false` (now floor‑safe and monotonic);
- a POST body with `comps` as a comma‑separated string was dropped (now parsed);
- `--api` with no value coerced to the literal `"true"` (now guarded).

## Testing

- `deno task test:ebay-pricing` — 18 tests: 8‑case reference matrix + property sweeps (price `≥ floor`, `netAtPrice ≥` margin, monotonic in age, undercut‑or‑floor, charm, schedule sanitation). All pass.
- `deno check main.ts` clean; new files lint‑clean.
- Endpoint + visual demo smoke‑tested live (Chromium/Playwright screenshot, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2JiU9edWa2XEBm2bgHqtW)_