### PR TITLE
Use the eBay pricing formula for the /e2e draft and ebay-listing autofill

### DIFF
--- a/.claude/skills/ebay-listing/SKILL.md
+++ b/.claude/skills/ebay-listing/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   description (and the photo when possible) from the product. It does NOT submit
   or publish — it leaves a ready-to-review draft. Pairs with the visual eBay-draft
   snapshot rendered by the Samples-Import app / EbayDraft component.
-allowed-tools: mcp__Claude_in_Chrome__navigate, mcp__Claude_in_Chrome__read_page, mcp__Claude_in_Chrome__get_page_text, mcp__Claude_in_Chrome__find, mcp__Claude_in_Chrome__form_input, mcp__Claude_in_Chrome__computer, mcp__Claude_in_Chrome__file_upload, mcp__Claude_in_Chrome__read_console_messages, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_product
+allowed-tools: mcp__Claude_in_Chrome__navigate, mcp__Claude_in_Chrome__read_page, mcp__Claude_in_Chrome__get_page_text, mcp__Claude_in_Chrome__find, mcp__Claude_in_Chrome__form_input, mcp__Claude_in_Chrome__computer, mcp__Claude_in_Chrome__file_upload, mcp__Claude_in_Chrome__read_console_messages, mcp__f520785f-7c81-4ad1-a212-026d9c945eb7__v1_tiktok_product, WebFetch
 ---
 
 # ebay-listing
@@ -27,10 +27,12 @@ If the Chrome extension isn't connected, ask the user to install/connect it
 ## Inputs
 
 The product to list, ideally already on hand from the import/lifecycle context:
-`name` (→ title), `price` (→ Buy It Now), condition (default **New** — these are
-fresh samples), `description`, an `image` URL, and the `productId`. If you only
-have a `productId` / PDP url, hydrate first via `…__v1_tiktok_product` (or
-data-pimp `/api/product-lookup/:id`) for the title/price/image.
+`name` (→ title), a `retail`/MSRP price (the TikTok price — the pricing input,
+NOT the Buy-It-Now directly), condition (default **New** — these are fresh
+samples), `description`, an `image` URL, and the `productId`. If you only have a
+`productId` / PDP url, hydrate first via `…__v1_tiktok_product` (or data-pimp
+`/api/product-lookup/:id`) for the title/price/image. The **Buy-It-Now price is
+computed by the pricing formula** (see Pricing below), not taken raw.
 
 ## Workflow
 
@@ -44,18 +46,52 @@ data-pimp `/api/product-lookup/:id`) for the title/price/image.
    the title input, condition selector, format/price (Buy It Now) input, and the
    description editor. eBay's DOM changes often, so locate by visible label, not
    a hardcoded selector.
-4. **Autofill** with `form_input` (or `computer` for rich controls):
+4. **Compute the Buy-It-Now price** with the eBay pricing formula — undercut the
+   competition, move fast, never below a fee-aware floor (see **Pricing** below).
+   You're already on eBay, so grab real comps first: eBay's search results for the
+   title (or the "Similar sold items" panel) are competitor prices. Then call
+   data-pimp `/api/ebay-price` with the product's `retail`/MSRP, `costBasis` (0
+   for a free sample), `condition`, and those `comps`, and use the returned
+   `price`. Surface its `explanation` to the user.
+5. **Autofill** with `form_input` (or `computer` for rich controls):
    - **Title** ← `name` (trim to eBay's 80-char limit).
    - **Condition** ← `New`.
-   - **Price / Buy It Now** ← `price` (the resale ask; default to the product's
-     price if no explicit ask).
+   - **Price / Buy It Now** ← the **recommended price from step 4** — a
+     floor-protected, charm-`.99` ask that undercuts the cheapest credible comp.
+     Never fill a price below the formula's returned `floor`.
    - **Description** ← `description` (or a sensible default: "Brand-new, sealed
      TikTok Shop sample. Ships fast from a smoke-free home.").
    - **Photo** ← the `image`: if eBay accepts an image URL or `file_upload` works,
      add it; otherwise leave photos and tell the user to drop the image in.
-5. **Stop at a reviewable draft. Do NOT submit/publish.** Leave the form filled
+6. **Stop at a reviewable draft. Do NOT submit/publish.** Leave the form filled
    and tell the user what was populated and what to check (category, item
    specifics, shipping) before they click **List it** themselves.
+
+## Pricing
+
+The Buy-It-Now price comes from the eBay pricing formula
+(`data-pimp/core/ebay-pricing.ts`), exposed as `GET|POST /api/ebay-price`. It
+undercuts the cheapest **credible** competitor, marks down the longer a unit
+sits, and never drops below a fee-aware floor (so a listing never loses money
+after eBay's ~13.25% + $0.30). Call it, e.g.:
+
+```
+GET https://thirsty.store/api/ebay-price?retail=89.99&costBasis=0&condition=new&comps=58,62,65
+# or POST JSON: { "retail": 89.99, "costBasis": 0, "condition": "new", "comps": [58,62,65] }
+```
+
+It returns `price` (the charm-`.99` Buy-It-Now to fill), plus `floor`, `anchor`,
+`netAtPrice`, `undercutFromAnchor`, `floorHit`, and a one-line `explanation`.
+Guidance:
+
+- **Pass comps when you have them.** Real eBay comps let the formula undercut the
+  actual market; with none it falls back to a conservative retail-based anchor.
+- **Respect the floor.** If `floorHit` is true the market is at/below break-even —
+  the returned `price` sits at the floor; don't hand-edit it lower.
+- **Relay the reasoning.** Tell the user what the `explanation` says (e.g.
+  "undercuts the cheapest comp $58 → $54.99, nets $47.40 after fees").
+- Try it yourself: `deno task demo:ebay-pricing`, or the visual demo at
+  `/demos/ebay-pricing`.
 
 ## Guardrails
 

--- a/static/e2e.html
+++ b/static/e2e.html
@@ -128,6 +128,7 @@
     .ebd-ph { width: 60px; height: 60px; border-radius: 8px; display: inline-grid; place-items: center; font-size: 30px; background: #f1f3f5; }
     .ebd-chip { position: absolute; top: -9px; right: 8px; background: #fff3e6; color: #b3560a; border: 1px solid #f3c08a;
       font-size: 11px; font-weight: 600; padding: 2px 9px; border-radius: 99px; animation: ebpulse 1.8s ease-in-out infinite; }
+    .ebd-rec { margin-top: 5px; color: #1b7a2e; font-size: 11.5px; font-weight: 600; display: flex; align-items: center; gap: 5px; }
     @keyframes ebpulse { 0%, 100% { opacity: .55; } 50% { opacity: 1; } }
     .ebd-foot { position: sticky; bottom: 0; background: #fff; border-top: 1px solid #e5e7eb; padding: 12px 16px;
       display: flex; align-items: center; justify-content: space-between; }
@@ -394,6 +395,54 @@
       } catch (e) { /* keep the curated fallback */ }
     }
 
+    // Illustrative competitor comps for the showcase, derived from retail, so the
+    // real pricing formula can demonstrate its headline move: UNDERCUTTING the
+    // market. These comp INPUTS are demo data; the price the draft shows is the
+    // genuine formula output from /api/ebay-price.
+    function synthComps(retail) {
+      var r = Number(retail) || 0;
+      if (r <= 0) return [];
+      return [round2(r * 0.78), round2(r * 0.86), round2(r * 0.92)];
+    }
+
+    // Price the hero with the real eBay pricing formula (core/ebay-pricing.ts via
+    // /api/ebay-price): undercut the competition, move fast, never below the
+    // fee-aware floor. Replaces the old naive retail*0.8 guess. Falls back silently
+    // to whatever salePrice is already set if the endpoint is unreachable.
+    async function priceHero(h) {
+      if (!h || h.__priced) return;
+      h.__priced = true;
+      try {
+        var res = await fetch("/api/ebay-price", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ retail: h.retail, costBasis: 0, condition: "new", comps: synthComps(h.retail) })
+        });
+        if (!res.ok) return;
+        var d = await res.json();
+        if (!d || !(Number(d.price) > 0)) return;
+        h.salePrice = round2(Number(d.price));
+        h.fees = Math.max(0, round2(h.salePrice - Number(d.netAtPrice)));
+        h.priceInfo = {
+          net: round2(Number(d.netAtPrice)),
+          cheapestComp: d.anchor,
+          undercut: Number(d.undercutFromAnchor),
+          anchorSource: d.anchorSource,
+          floorHit: !!d.floorHit
+        };
+        recompute();
+      } catch (e) { /* keep the fallback price */ }
+    }
+
+    // One-line reason for the recommended eBay price, shown under the draft's price.
+    function priceNote(h) {
+      var pi = h && h.priceInfo; if (!pi) return "";
+      if (pi.anchorSource === "comp" && pi.cheapestComp != null && !pi.floorHit && pi.undercut > 0) {
+        return "undercuts market (~" + usd(pi.cheapestComp) + ") · nets " + usd(pi.net) + " after eBay fees";
+      }
+      return "priced to move · nets " + usd(pi.net) + " after eBay fees";
+    }
+
     var cursor = $("cursor"), ring = $("ring");
     function moveTo(el, fast) {
       var r = el.getBoundingClientRect();
@@ -516,7 +565,9 @@
           '<div class="ebd-fld"><label>Photos</label><div class="ebd-box" id="f0"><span class="ebd-ph" style="background:' + TILE[0] + '">' + media(hero) + '</span></div><span class="ebd-chip">☝ autofill photo</span></div>' +
           '<div class="ebd-fld"><label>Listing title</label><div class="ebd-box" id="f1">' + esc(hero.name) + '</div><span class="ebd-chip">☝ autofill title</span></div>' +
           '<div class="ebd-row"><div class="ebd-fld"><label>Condition</label><div class="ebd-box" id="f2"><span class="ebd-pill">New</span></div><span class="ebd-chip">☝ autofill</span></div>' +
-          '<div class="ebd-fld"><label>Price · Buy It Now</label><div class="ebd-box" id="f3">' + usd(hero.salePrice) + '</div><span class="ebd-chip">☝ autofill price</span></div></div>' +
+          '<div class="ebd-fld"><label>Price · Buy It Now</label><div class="ebd-box" id="f3">' + usd(hero.salePrice) + '</div>' +
+            (hero.priceInfo ? '<div class="ebd-rec">🏷 ' + esc(priceNote(hero)) + '</div>' : '') +
+            '<span class="ebd-chip">☝ autofill price</span></div></div>' +
           '<div class="ebd-fld"><label>Description</label><div class="ebd-box" id="f4" style="color:#444;line-height:1.55">Brand-new, sealed TikTok Shop sample. Ships same-day from a smoke-free home. See item specifics for details.</div><span class="ebd-chip">☝ autofill description</span></div>' +
         '</div>' +
         '<div class="ebd-foot"><span class="ebd-meta">1 photo · ' + usd(hero.salePrice) + ' · productId ' + esc(hero.productId || "1731301163454206492") + '</span>' +
@@ -573,6 +624,9 @@
       tallyEl.textContent = "$0.00";
       kioskEl.innerHTML = '<div class="kiosk-loading"><div class="spinner"></div><div>Loading Inventory Manager…</div></div>';
       $("kiosk-sub").textContent = "loading…";
+      // Recommend the eBay Buy-It-Now price with the real formula before the draft
+      // shows it (invisible under the loading spinner; falls back if offline).
+      await priceHero(hero);
       moveTo($("creator"));
       await sleep(400);
       await phaseOrderList();
@@ -602,7 +656,7 @@
         "",
         "2. Cleared to Sell — use the sample-lifecycle skill to set the \"" + hName + "\" sample's status to cleared_to_sell.",
         "",
-        "3. List on eBay — use list_on_marketplace to draft an eBay listing for it at " + hSale + ", then use the ebay-listing browser skill to open eBay's create-listing page pre-filled (do not publish).",
+        "3. List on eBay — use list_on_marketplace to draft an eBay listing for it at the recommended price " + hSale + " (from the eBay pricing formula — undercuts the market, protected by a fee-aware floor), then use the ebay-listing browser skill to open eBay's create-listing page pre-filled (do not publish).",
         "",
         "4. Mark sold — use the sample-lifecycle skill to mark it sold on eBay for " + hSale + ", attributing the resale revenue to " + c + ".",
         "",


### PR DESCRIPTION
Follow-up to #96 (the pricing formula, now on `main`). Wires the recommended price into the two places that actually pick a resale price, replacing the naive `retail * 0.8`.

## `/e2e` showcase eBay draft (`static/e2e.html`)
- The showcase now recommends the hero's Buy‑It‑Now price via `POST /api/ebay-price` before the draft displays it (under the loading spinner, so it's invisible; falls back silently to the old price if the endpoint is unreachable).
- To demonstrate the formula's headline behavior — **undercutting the market** — the hero is priced against a few illustrative competitor comps derived from retail. These comp *inputs* are demo data; the price shown is the genuine formula output.
- The eBay draft surfaces the reasoning under the price, e.g. **"🏷 undercuts market (~$70.19) · nets $56.95 after eBay fees"**, and the profit tally / finale now follow the formula's `netAtPrice`.
- The "Recreate with Claude" prompt mentions the recommended, floor‑protected price.

Verified in‑browser: the Ninja hero drafts at **$65.99** (undercutting the cheapest comp by $4.20), no console errors.

## `ebay-listing` skill (`.claude/skills/ebay-listing/SKILL.md`)
- The Buy‑It‑Now autofill now **computes the price from the formula** instead of taking the raw product price: gather real eBay comps from the page (search results / "Similar sold items"), call `/api/ebay-price` with `retail`/`costBasis`/`condition`/`comps`, fill the returned floor‑protected charm‑`.99` ask, and relay its `explanation` to the user.
- Adds a **Pricing** section documenting the endpoint and guidance (pass comps when you have them, respect the floor, relay the reasoning), and adds `WebFetch` to `allowed-tools` so the price lookup doesn't disturb the eBay tab.

## Notes
- No changes to the formula engine, its tests, or the API — this only consumes them. The existing suite (`deno task test:ebay-pricing`, 20 tests) and `deno check` remain green; `static/e2e.html` degrades gracefully offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2JiU9edWa2XEBm2bgHqtW)_