### PR TITLE
Role-based access flags + stale-checkout Discord alerts

### DIFF
--- a/core/checkout-alerts.ts
+++ b/core/checkout-alerts.ts
@@ -1,0 +1,313 @@
+/**
+ * Stale-checkout alerting: find samples stuck in `checked_out` past an
+ * acceptable time and ping a Discord channel so someone chases them down.
+ *
+ * A sample enters `checked_out` when it's assigned/imported to a creator
+ * (`recordSampleAssignment` / `recordSampleImport` stamp `checked_out_at`) or
+ * flipped via `recordSampleStatus`. This module reads the `samples` rows still
+ * in that status, ages each from `checked_out_at` (falling back to `created_at`
+ * for rows checked out before that column was stamped), and alerts on any past
+ * the threshold.
+ *
+ * Wiring: a `Deno.cron` in main.ts calls `runCheckoutAlerts()` on a schedule.
+ * Config (all optional, sensible defaults):
+ *   - DISCORD_WEBHOOK_URL          Discord webhook. UNSET → alerts disabled.
+ *   - CHECKOUT_ALERT_HOURS         Stale threshold in hours (default 72 = 3d).
+ *   - CHECKOUT_ALERT_REPEAT_HOURS  Re-alert throttle per sample (default 24).
+ *
+ * Re-alert throttle: the cron runs repeatedly, so an already-flagged sample
+ * would spam the channel every run. We remember each alerted sample in the
+ * shared KV cache for `CHECKOUT_ALERT_REPEAT_HOURS` and skip it until then —
+ * best-effort (a cache miss just means an extra ping, never a missed one).
+ *
+ * The selection + message builders are pure and unit-tested; `runCheckoutAlerts`
+ * takes injectable deps (DB / cache / notifier) so its orchestration is testable
+ * without a database or network.
+ */
+import { Samples } from "../db.ts";
+import { cacheGet, cacheSet } from "./cache.ts";
+import { envValue } from "./graylog.ts";
+
+/** Row shape we read off `public.samples` (structural — `Samples.filter` → any). */
+export interface CheckoutRow {
+  id?: unknown;
+  qr_code?: unknown;
+  name?: unknown;
+  status?: unknown;
+  checked_out_to?: unknown;
+  checked_out_at?: unknown;
+  created_at?: unknown;
+}
+
+export interface StaleCheckout {
+  sampleId: number | null;
+  productId: string | null;
+  name: string | null;
+  checkedOutTo: string | null;
+  /** ISO timestamp the checkout clock started from. */
+  since: string;
+  /** Whole hours in `checked_out` as of `now`. */
+  ageHours: number;
+  /** Whether `since` fell back to `created_at` (no stamped `checked_out_at`). */
+  approximate: boolean;
+}
+
+export const DEFAULT_THRESHOLD_HOURS = 72;
+export const DEFAULT_REPEAT_HOURS = 24;
+// Cap on rows scanned per run (also db.ts's hard max for `limit`). The scan
+// orders OLDEST-first (see runCheckoutAlerts) so that if live checkouts ever
+// exceed this cap, truncation drops the freshest rows — never the stale ones
+// the alert exists to catch.
+const SCAN_LIMIT = 500;
+
+// pg returns timestamps as JS `Date`; the API/JSON paths hand back ISO strings.
+// Accept either (and reject anything unparseable) so age is never a fake 0.
+function parseTime(value: unknown): number | null {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : null;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const t = Date.parse(value);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+}
+
+function str(value: unknown): string | null {
+  const s = String(value ?? "").trim();
+  return s || null;
+}
+
+/**
+ * Pure selection: given `checked_out` sample rows, return those aged at or past
+ * `thresholdHours`, oldest first. Rows in any other status, or with no parseable
+ * checkout/created timestamp, are skipped (never guessed as brand-new).
+ */
+export function findStaleCheckouts(
+  rows: CheckoutRow[],
+  opts: { now: number; thresholdHours: number },
+): StaleCheckout[] {
+  const thresholdMs = Math.max(0, opts.thresholdHours) * 3_600_000;
+  const stale: StaleCheckout[] = [];
+
+  for (const row of rows) {
+    if (str(row.status) !== "checked_out") continue;
+
+    const stampedAt = parseTime(row.checked_out_at);
+    const since = stampedAt ?? parseTime(row.created_at);
+    if (since === null) continue; // no basis to age it — don't invent one
+
+    const ageMs = opts.now - since;
+    if (ageMs < thresholdMs) continue;
+
+    const rawId = Number(row.id);
+    stale.push({
+      sampleId: Number.isFinite(rawId) ? rawId : null,
+      productId: str(row.qr_code),
+      name: str(row.name),
+      checkedOutTo: str(row.checked_out_to),
+      since: new Date(since).toISOString(),
+      ageHours: Math.floor(ageMs / 3_600_000),
+      approximate: stampedAt === null,
+    });
+  }
+
+  stale.sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+  return stale;
+}
+
+/** Stable throttle key for a stale sample (prefers the sample id). */
+export function alertKey(item: StaleCheckout): string {
+  if (item.sampleId !== null) return `sample:${item.sampleId}`;
+  if (item.productId) return `product:${item.productId}`;
+  return `since:${item.since}:${item.name ?? ""}`;
+}
+
+function humanAge(hours: number): string {
+  if (hours < 48) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const rem = hours % 24;
+  return rem ? `${days}d ${rem}h` : `${days}d`;
+}
+
+/** The Discord webhook JSON body (content + one summary embed). */
+export interface DiscordBody {
+  content?: string;
+  embeds?: Array<{
+    title: string;
+    description: string;
+    color: number;
+    footer?: { text: string };
+  }>;
+}
+
+// Discord caps an embed description at 4096 chars; keep the list well under it.
+const MAX_LISTED = 25;
+
+/**
+ * Build the Discord message for a batch of stale checkouts. Pure — no env, no
+ * network — so the exact payload is unit-tested.
+ */
+export function buildCheckoutAlertContent(
+  stale: StaleCheckout[],
+  opts: { thresholdHours: number },
+): DiscordBody {
+  const lines = stale.slice(0, MAX_LISTED).map((s) => {
+    const who = s.checkedOutTo ? ` → ${s.checkedOutTo}` : "";
+    const id = s.sampleId !== null ? ` \`#${s.sampleId}\`` : "";
+    const approx = s.approximate ? " (approx.)" : "";
+    return `• **${s.name ?? s.productId ?? "Unknown sample"}**${id}${who} — ${
+      humanAge(s.ageHours)
+    }${approx}`;
+  });
+  if (stale.length > MAX_LISTED) {
+    lines.push(`…and ${stale.length - MAX_LISTED} more.`);
+  }
+
+  const noun = stale.length === 1 ? "sample" : "samples";
+  return {
+    content:
+      `⚠️ ${stale.length} ${noun} checked out longer than ${opts.thresholdHours}h`,
+    embeds: [{
+      title: "Stale checkouts",
+      description: lines.join("\n"),
+      color: 0xf59e0b, // amber
+      footer: { text: "Thirsty OS · sample tracker" },
+    }],
+  };
+}
+
+/** POST a prebuilt body to a Discord webhook. Best-effort → boolean. */
+export async function postDiscord(
+  webhookUrl: string,
+  body: DiscordBody,
+): Promise<boolean> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface RunCheckoutAlertsResult {
+  /** False when DISCORD_WEBHOOK_URL is unset (feature off). */
+  enabled: boolean;
+  /** checked_out rows scanned. */
+  checked: number;
+  /** rows past the threshold. */
+  stale: number;
+  /** stale rows newly alerted this run (excludes throttled). */
+  alerted: number;
+  /** stale rows skipped by the re-alert throttle. */
+  skipped: number;
+  /** whether the Discord post (if any) succeeded. */
+  ok: boolean;
+}
+
+/** Injectable seams so the orchestration is testable without DB/cache/network. */
+export interface RunCheckoutAlertsDeps {
+  now?: number;
+  thresholdHours?: number;
+  repeatHours?: number;
+  webhookUrl?: string | null;
+  listCheckedOut?: () => Promise<CheckoutRow[]>;
+  wasAlerted?: (key: string) => Promise<boolean>;
+  markAlerted?: (key: string, ttlMs: number) => Promise<void>;
+  notify?: (webhookUrl: string, body: DiscordBody) => Promise<boolean>;
+  log?: (msg: string) => void;
+}
+
+function envHours(name: string, fallback: number): number {
+  const raw = Number(envValue(name));
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+/**
+ * Scan `checked_out` samples, alert Discord about any past the threshold that
+ * we haven't already pinged inside the repeat window, and remember what we
+ * alerted. Safe to call on a cron: no webhook configured → no-op.
+ */
+export async function runCheckoutAlerts(
+  deps: RunCheckoutAlertsDeps = {},
+): Promise<RunCheckoutAlertsResult> {
+  const now = deps.now ?? Date.now();
+  const thresholdHours = deps.thresholdHours ??
+    envHours("CHECKOUT_ALERT_HOURS", DEFAULT_THRESHOLD_HOURS);
+  const repeatHours = deps.repeatHours ??
+    envHours("CHECKOUT_ALERT_REPEAT_HOURS", DEFAULT_REPEAT_HOURS);
+  const webhookUrl = deps.webhookUrl ?? envValue("DISCORD_WEBHOOK_URL") ?? null;
+  const log = deps.log ?? ((m: string) => console.log(m));
+
+  const empty: RunCheckoutAlertsResult = {
+    enabled: !!webhookUrl,
+    checked: 0,
+    stale: 0,
+    alerted: 0,
+    skipped: 0,
+    ok: true,
+  };
+
+  if (!webhookUrl) {
+    log("[checkout-alerts] DISCORD_WEBHOOK_URL unset — alerts disabled");
+    return empty;
+  }
+
+  const listCheckedOut = deps.listCheckedOut ??
+    (() =>
+      Samples.filter(
+        { status: "checked_out" },
+        // OLDEST-first: if checkouts exceed SCAN_LIMIT, keep the stalest rows
+        // (the ones we alert on) and let the newest fall off the cap.
+        "checked_out_at",
+        SCAN_LIMIT,
+      ) as Promise<CheckoutRow[]>);
+  const wasAlerted = deps.wasAlerted ??
+    (async (key: string) =>
+      (await cacheGet<number>("checkout-alert", key)) !== null);
+  const markAlerted = deps.markAlerted ??
+    ((key: string, ttlMs: number) =>
+      cacheSet("checkout-alert", key, now, ttlMs));
+  const notify = deps.notify ?? postDiscord;
+
+  const rows = await listCheckedOut();
+  const stale = findStaleCheckouts(rows, { now, thresholdHours });
+
+  // Throttle: drop samples we've already pinged inside the repeat window.
+  const fresh: StaleCheckout[] = [];
+  let skipped = 0;
+  for (const item of stale) {
+    if (await wasAlerted(alertKey(item))) {
+      skipped++;
+      continue;
+    }
+    fresh.push(item);
+  }
+
+  if (fresh.length === 0) {
+    return { ...empty, checked: rows.length, stale: stale.length, skipped };
+  }
+
+  const body = buildCheckoutAlertContent(fresh, { thresholdHours });
+  const ok = await notify(webhookUrl, body);
+
+  // Only remember what we actually delivered — a failed post retries next run.
+  if (ok) {
+    const ttlMs = repeatHours * 3_600_000;
+    for (const item of fresh) await markAlerted(alertKey(item), ttlMs);
+  }
+
+  return {
+    enabled: true,
+    checked: rows.length,
+    stale: stale.length,
+    alerted: ok ? fresh.length : 0,
+    skipped,
+    ok,
+  };
+}

--- a/core/checkout-alerts_test.ts
+++ b/core/checkout-alerts_test.ts
@@ -1,0 +1,239 @@
+import { expect } from "@std/expect";
+import {
+  alertKey,
+  buildCheckoutAlertContent,
+  type CheckoutRow,
+  findStaleCheckouts,
+  runCheckoutAlerts,
+  type StaleCheckout,
+} from "./checkout-alerts.ts";
+
+const NOW = Date.parse("2026-07-01T00:00:00.000Z");
+const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
+
+Deno.test("findStaleCheckouts flags rows at or past the threshold, oldest first", () => {
+  const rows: CheckoutRow[] = [
+    { id: 1, name: "A", status: "checked_out", checked_out_at: hoursAgo(100) },
+    { id: 2, name: "B", status: "checked_out", checked_out_at: hoursAgo(80) },
+    { id: 3, name: "C", status: "checked_out", checked_out_at: hoursAgo(72) },
+  ];
+  const stale = findStaleCheckouts(rows, { now: NOW, thresholdHours: 72 });
+  expect(stale.map((s) => s.sampleId)).toEqual([1, 2, 3]); // oldest → newest
+  expect(stale[0].ageHours).toBe(100);
+});
+
+Deno.test("findStaleCheckouts ignores fresh checkouts and other statuses", () => {
+  const rows: CheckoutRow[] = [
+    {
+      id: 1,
+      name: "fresh",
+      status: "checked_out",
+      checked_out_at: hoursAgo(10),
+    },
+    {
+      id: 2,
+      name: "avail",
+      status: "available",
+      checked_out_at: hoursAgo(500),
+    },
+    { id: 3, name: "sold", status: "sold", checked_out_at: hoursAgo(500) },
+  ];
+  expect(findStaleCheckouts(rows, { now: NOW, thresholdHours: 72 })).toEqual(
+    [],
+  );
+});
+
+Deno.test("threshold boundary is inclusive (>= threshold)", () => {
+  const at = [{ id: 1, status: "checked_out", checked_out_at: hoursAgo(72) }];
+  const under = [{
+    id: 1,
+    status: "checked_out",
+    checked_out_at: hoursAgo(71),
+  }];
+  expect(findStaleCheckouts(at, { now: NOW, thresholdHours: 72 })).toHaveLength(
+    1,
+  );
+  expect(findStaleCheckouts(under, { now: NOW, thresholdHours: 72 }))
+    .toHaveLength(0);
+});
+
+Deno.test("findStaleCheckouts falls back to created_at and marks it approximate", () => {
+  const rows: CheckoutRow[] = [
+    { id: 1, status: "checked_out", created_at: hoursAgo(200) }, // no checked_out_at
+  ];
+  const stale = findStaleCheckouts(rows, { now: NOW, thresholdHours: 72 });
+  expect(stale).toHaveLength(1);
+  expect(stale[0].approximate).toBe(true);
+  expect(stale[0].ageHours).toBe(200);
+});
+
+Deno.test("findStaleCheckouts skips rows with no parseable timestamp", () => {
+  const rows: CheckoutRow[] = [
+    { id: 1, status: "checked_out", checked_out_at: null, created_at: "" },
+    { id: 2, status: "checked_out", checked_out_at: "not-a-date" },
+  ];
+  expect(findStaleCheckouts(rows, { now: NOW, thresholdHours: 72 })).toEqual(
+    [],
+  );
+});
+
+Deno.test("findStaleCheckouts accepts Date objects (pg timestamps)", () => {
+  const rows: CheckoutRow[] = [
+    {
+      id: 1,
+      status: "checked_out",
+      checked_out_at: new Date(NOW - 90 * 3_600_000),
+    },
+  ];
+  const stale = findStaleCheckouts(rows, { now: NOW, thresholdHours: 72 });
+  expect(stale).toHaveLength(1);
+  expect(stale[0].ageHours).toBe(90);
+});
+
+Deno.test("alertKey prefers sample id, then product id, then a synthesized key", () => {
+  const base: StaleCheckout = {
+    sampleId: 7,
+    productId: "p1",
+    name: "n",
+    checkedOutTo: null,
+    since: hoursAgo(80),
+    ageHours: 80,
+    approximate: false,
+  };
+  expect(alertKey(base)).toBe("sample:7");
+  expect(alertKey({ ...base, sampleId: null })).toBe("product:p1");
+  expect(alertKey({ ...base, sampleId: null, productId: null }))
+    .toBe(`since:${base.since}:n`);
+});
+
+Deno.test("buildCheckoutAlertContent summarizes the batch and names the threshold", () => {
+  const stale: StaleCheckout[] = [{
+    sampleId: 42,
+    productId: "p",
+    name: "Cupids Desire Drops",
+    checkedOutTo: "@boosteddealsdaily",
+    since: hoursAgo(90),
+    ageHours: 90,
+    approximate: false,
+  }];
+  const body = buildCheckoutAlertContent(stale, { thresholdHours: 72 });
+  expect(body.content).toContain("1 sample");
+  expect(body.content).toContain("72h");
+  expect(body.embeds?.[0].description).toContain("Cupids Desire Drops");
+  expect(body.embeds?.[0].description).toContain("@boosteddealsdaily");
+  expect(body.embeds?.[0].description).toContain("#42");
+  expect(body.embeds?.[0].description).toContain("3d 18h"); // 90h humanized
+});
+
+Deno.test("buildCheckoutAlertContent truncates long batches with an overflow line", () => {
+  const many: StaleCheckout[] = Array.from({ length: 30 }, (_, i) => ({
+    sampleId: i,
+    productId: null,
+    name: `S${i}`,
+    checkedOutTo: null,
+    since: hoursAgo(100),
+    ageHours: 100,
+    approximate: false,
+  }));
+  const body = buildCheckoutAlertContent(many, { thresholdHours: 72 });
+  expect(body.content).toContain("30 samples");
+  expect(body.embeds?.[0].description).toContain("…and 5 more.");
+});
+
+Deno.test("runCheckoutAlerts no-ops when the webhook is unset", async () => {
+  let listed = false;
+  const r = await runCheckoutAlerts({
+    webhookUrl: null,
+    listCheckedOut: () => {
+      listed = true;
+      return Promise.resolve([]);
+    },
+  });
+  expect(r.enabled).toBe(false);
+  expect(r.alerted).toBe(0);
+  expect(listed).toBe(false); // returns before ever touching the DB
+});
+
+Deno.test("runCheckoutAlerts alerts fresh stale samples and records them", async () => {
+  const remembered = new Set<string>();
+  const posted: unknown[] = [];
+  const r = await runCheckoutAlerts({
+    now: NOW,
+    thresholdHours: 72,
+    repeatHours: 24,
+    webhookUrl: "https://discord.test/webhook",
+    listCheckedOut: () =>
+      Promise.resolve([
+        { id: 1, status: "checked_out", checked_out_at: hoursAgo(100) },
+        { id: 2, status: "checked_out", checked_out_at: hoursAgo(10) }, // fresh
+      ]),
+    wasAlerted: (k) => Promise.resolve(remembered.has(k)),
+    markAlerted: (k) => {
+      remembered.add(k);
+      return Promise.resolve();
+    },
+    notify: (_url, body) => {
+      posted.push(body);
+      return Promise.resolve(true);
+    },
+  });
+  expect(r).toEqual({
+    enabled: true,
+    checked: 2,
+    stale: 1,
+    alerted: 1,
+    skipped: 0,
+    ok: true,
+  });
+  expect(posted).toHaveLength(1);
+  expect(remembered.has("sample:1")).toBe(true);
+});
+
+Deno.test("runCheckoutAlerts throttles samples already alerted in the window", async () => {
+  let posts = 0;
+  const r = await runCheckoutAlerts({
+    now: NOW,
+    thresholdHours: 72,
+    webhookUrl: "https://discord.test/webhook",
+    listCheckedOut: () =>
+      Promise.resolve([{
+        id: 1,
+        status: "checked_out",
+        checked_out_at: hoursAgo(100),
+      }]),
+    wasAlerted: () => Promise.resolve(true), // already pinged
+    markAlerted: () => Promise.resolve(),
+    notify: () => {
+      posts++;
+      return Promise.resolve(true);
+    },
+  });
+  expect(r.stale).toBe(1);
+  expect(r.skipped).toBe(1);
+  expect(r.alerted).toBe(0);
+  expect(posts).toBe(0); // nothing new → no Discord call
+});
+
+Deno.test("runCheckoutAlerts does not remember samples when the post fails", async () => {
+  const remembered = new Set<string>();
+  const r = await runCheckoutAlerts({
+    now: NOW,
+    thresholdHours: 72,
+    webhookUrl: "https://discord.test/webhook",
+    listCheckedOut: () =>
+      Promise.resolve([{
+        id: 1,
+        status: "checked_out",
+        checked_out_at: hoursAgo(100),
+      }]),
+    wasAlerted: (k) => Promise.resolve(remembered.has(k)),
+    markAlerted: (k) => {
+      remembered.add(k);
+      return Promise.resolve();
+    },
+    notify: () => Promise.resolve(false), // delivery failed
+  });
+  expect(r.ok).toBe(false);
+  expect(r.alerted).toBe(0);
+  expect(remembered.size).toBe(0); // retried next run
+});

--- a/core/lifecycle.ts
+++ b/core/lifecycle.ts
@@ -499,7 +499,12 @@ export async function recordSampleStatus(
   let reason: string | undefined;
   if (row) {
     try {
-      await Samples.update(String(row.id), { status });
+      // Stamp the checkout clock when a plain status flip enters `checked_out`
+      // (assignment/import already do this) so the stale-checkout alert can age
+      // the row. Other statuses leave `checked_out_at` untouched.
+      const patch: Record<string, unknown> = { status };
+      if (status === "checked_out") patch.checked_out_at = now;
+      await Samples.update(String(row.id), patch);
       updated = true;
     } catch (error) {
       reason = error instanceof Error ? error.message : String(error);

--- a/core/roles.json
+++ b/core/roles.json
@@ -1,0 +1,41 @@
+{
+  "defaultRole": "dj",
+  "flags": [
+    { "id": "folder.apps", "label": "Apps folder" },
+    { "id": "folder.demos", "label": "Demos folder" },
+    { "id": "folder.member", "label": "Member folder" },
+    { "id": "app.productAnalysis", "label": "Product Analysis app" },
+    { "id": "app.inventory", "label": "Inventory (LP Sample Tracker)" },
+    { "id": "app.kiosk", "label": "Kiosk / checkout" },
+    { "id": "app.installExtension", "label": "Install Extension helper" },
+    { "id": "ops.debugCounts", "label": "Row-count debug endpoint" },
+    {
+      "id": "ops.checkoutAlerts",
+      "label": "Stakeholder for stale-checkout alerts"
+    }
+  ],
+  "roles": [
+    {
+      "id": "dj",
+      "name": "DJ",
+      "boot": "default",
+      "flags": { "*": true }
+    },
+    {
+      "id": "ka",
+      "name": "Karl · Warehouse",
+      "boot": "warehouse",
+      "flags": {
+        "folder.apps": true,
+        "app.inventory": true,
+        "app.kiosk": true,
+        "app.installExtension": true,
+        "app.productAnalysis": false,
+        "folder.demos": false,
+        "folder.member": false,
+        "ops.debugCounts": false,
+        "ops.checkoutAlerts": true
+      }
+    }
+  ]
+}

--- a/core/roles.ts
+++ b/core/roles.ts
@@ -1,0 +1,105 @@
+/**
+ * Role-based access control for Thirsty OS — a config-driven map of team
+ * members ("roles") to capability flags.
+ *
+ * `core/roles.json` is the SINGLE SOURCE OF TRUTH: adding a team member or
+ * changing what they can see is a config edit, never a code change. The OS
+ * shell (static/os.js) enforces the flags client-side — it filters the desktop
+ * folders/apps a role may open and picks their boot layout. The server exposes
+ * the same config verbatim at `/api/roles` and injects it into the OS shell as
+ * `window.THIRSTY_RBAC` so the browser and the backend read one list.
+ *
+ * IMPORTANT: this is per-device UX gating, NOT a security boundary. The OS has
+ * no auth/session (see static/os.js), so a role only decides which launchers a
+ * given browser shows — it cannot protect a same-origin URL that someone types
+ * directly. Treat it like a "kiosk profile", not like server-enforced authz.
+ *
+ * Flag resolution (see `roleHasFlag`): an explicit per-role value wins; a
+ * wildcard `"*"` supplies the default for any flag the role doesn't list; an
+ * unknown role or unlisted flag with no wildcard denies by default.
+ */
+import config from "./roles.json" with { type: "json" };
+
+export interface FlagDef {
+  id: string;
+  label: string;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+  /** Boot-layout key the OS shell branches on (e.g. "default", "warehouse"). */
+  boot: string;
+  /** Per-flag grants; `"*": true` grants every flag not explicitly overridden. */
+  flags: Record<string, boolean>;
+}
+
+export interface RolesConfig {
+  defaultRole: string;
+  flags: FlagDef[];
+  roles: Role[];
+}
+
+// Two-step cast: the JSON import infers narrow literal flag keys (with the
+// wildcard `"*"`), which don't structurally match `Record<string, boolean>`.
+const CONFIG = config as unknown as RolesConfig;
+
+/** The configured fallback role id (used when a stored role is unknown). */
+export const DEFAULT_ROLE_ID: string = CONFIG.defaultRole;
+
+/** Every known capability flag, in declaration order. */
+export const FLAGS: FlagDef[] = CONFIG.flags;
+
+/** All roles, in declaration order. */
+export function listRoles(): Role[] {
+  return CONFIG.roles;
+}
+
+/** Look up a role by id, or null if it isn't configured. */
+export function getRole(id: string): Role | null {
+  const key = String(id ?? "").trim();
+  return CONFIG.roles.find((r) => r.id === key) ?? null;
+}
+
+/**
+ * Resolve one flag against a role's grant map. Explicit per-flag value wins;
+ * otherwise a wildcard `"*"` supplies the default; otherwise (unlisted flag, no
+ * wildcard) access is denied. Kept as a standalone pure fn so the precedence —
+ * including "explicit `false` beats `"*": true`" — is unit-testable independent
+ * of the config, and so static/os.js's `roleAllows` can mirror it exactly.
+ */
+export function resolveFlag(
+  flags: Record<string, boolean>,
+  flag: string,
+): boolean {
+  const explicit = flags[flag];
+  if (typeof explicit === "boolean") return explicit;
+  return flags["*"] === true;
+}
+
+/**
+ * Does `roleId` hold `flag`? An unknown role is denied every flag; otherwise the
+ * role's grant map is resolved via `resolveFlag`.
+ */
+export function roleHasFlag(roleId: string, flag: string): boolean {
+  const role = getRole(roleId);
+  if (!role) return false;
+  return resolveFlag(role.flags, flag);
+}
+
+/**
+ * The minimal, browser-safe view of the config injected into the OS shell as
+ * `globalThis.THIRSTY_RBAC` and served from `/api/roles`. Same shape both places
+ * so the client and any external consumer read one contract.
+ */
+export function rolesClientConfig(): {
+  defaultRole: string;
+  flags: FlagDef[];
+  roles: Role[];
+} {
+  return {
+    defaultRole: DEFAULT_ROLE_ID,
+    flags: FLAGS,
+    roles: CONFIG.roles,
+  };
+}

--- a/core/roles_test.ts
+++ b/core/roles_test.ts
@@ -1,0 +1,83 @@
+import { expect } from "@std/expect";
+import {
+  DEFAULT_ROLE_ID,
+  FLAGS,
+  getRole,
+  listRoles,
+  resolveFlag,
+  roleHasFlag,
+  rolesClientConfig,
+} from "./roles.ts";
+
+Deno.test("the configured default role exists in the role list", () => {
+  expect(getRole(DEFAULT_ROLE_ID)).not.toBeNull();
+});
+
+Deno.test("listRoles returns every configured role, in order", () => {
+  const ids = listRoles().map((r) => r.id);
+  expect(ids).toContain("dj");
+  expect(ids).toContain("ka");
+});
+
+Deno.test("getRole trims and misses unknown roles", () => {
+  expect(getRole("  dj  ")?.id).toBe("dj");
+  expect(getRole("nobody")).toBeNull();
+  expect(getRole("")).toBeNull();
+});
+
+Deno.test("wildcard role grants every flag", () => {
+  // DJ is `"*": true` — every declared flag resolves true.
+  for (const f of FLAGS) {
+    expect(roleHasFlag("dj", f.id)).toBe(true);
+  }
+  // ...even a flag that isn't declared at all.
+  expect(roleHasFlag("dj", "some.future.flag")).toBe(true);
+});
+
+Deno.test("explicit per-role false overrides the wildcard default", () => {
+  // Karl can open Inventory/Kiosk but not the Demos/Member folders.
+  expect(roleHasFlag("ka", "app.inventory")).toBe(true);
+  expect(roleHasFlag("ka", "app.kiosk")).toBe(true);
+  expect(roleHasFlag("ka", "folder.demos")).toBe(false);
+  expect(roleHasFlag("ka", "folder.member")).toBe(false);
+  expect(roleHasFlag("ka", "app.productAnalysis")).toBe(false);
+});
+
+Deno.test("a role without a wildcard denies flags it doesn't list", () => {
+  // Karl has no `"*"`, so an unlisted flag is denied by default.
+  expect(roleHasFlag("ka", "some.unlisted.flag")).toBe(false);
+});
+
+Deno.test("resolveFlag: explicit false beats a wildcard grant (precedence)", () => {
+  // The design's headline promise: `"*": true` grants all, but an explicit
+  // `false` denies that one flag. No configured role currently has BOTH, so this
+  // pins the precedence directly against the resolver — a regression that
+  // consulted `"*"` before the explicit value would flip this to true.
+  const flags = { "*": true, "app.locked": false };
+  expect(resolveFlag(flags, "app.locked")).toBe(false); // explicit wins
+  expect(resolveFlag(flags, "app.anything")).toBe(true); // wildcard default
+});
+
+Deno.test("resolveFlag: explicit true beats an absent/false wildcard", () => {
+  expect(resolveFlag({ "app.x": true }, "app.x")).toBe(true);
+  expect(resolveFlag({ "*": false, "app.x": true }, "app.x")).toBe(true);
+  expect(resolveFlag({ "app.x": true }, "app.y")).toBe(false); // no wildcard → deny
+});
+
+Deno.test("unknown roles are denied every flag", () => {
+  expect(roleHasFlag("nobody", "app.inventory")).toBe(false);
+});
+
+Deno.test("rolesClientConfig is a stable, browser-safe view", () => {
+  const cfg = rolesClientConfig();
+  expect(cfg.defaultRole).toBe(DEFAULT_ROLE_ID);
+  expect(Array.isArray(cfg.roles)).toBe(true);
+  expect(Array.isArray(cfg.flags)).toBe(true);
+  // Every role carries the fields the OS shell needs to render + gate.
+  for (const r of cfg.roles) {
+    expect(typeof r.id).toBe("string");
+    expect(typeof r.name).toBe("string");
+    expect(typeof r.boot).toBe("string");
+    expect(typeof r.flags).toBe("object");
+  }
+});

--- a/main.ts
+++ b/main.ts
@@ -50,6 +50,8 @@ import {
 } from "./core/graylog.ts";
 import { renderBarcodePng } from "./core/barcode.ts";
 import { databaseUrlError, getDatabaseUrl } from "./core/db-url.ts";
+import { runCheckoutAlerts } from "./core/checkout-alerts.ts";
+import { rolesClientConfig } from "./core/roles.ts";
 
 // Cleaned once (repairs stray quotes/whitespace/`DATABASE_URL=` prefix that
 // would otherwise make pg resolve host "base"); see core/db-url.ts.
@@ -453,6 +455,15 @@ function renderSPAShell(): Response {
 // Thirsty OS desktop shell — the front door at thirsty.store. Folders launch
 // each app (the storefront, the sample tracker, etc.) in draggable windows.
 function renderOSShell(): Response {
+  // Roles/flags come from core/roles.json. The <select> options render from it,
+  // and the same object is inlined as `globalThis.THIRSTY_RBAC` so os.js gates
+  // the desktop from one source. Escape `<` in the JSON so a role name can't
+  // break out of the inline <script>.
+  const rbac = rolesClientConfig();
+  const roleOptions = rbac.roles
+    .map((r) => `<option value="${escapeHtml(r.id)}">${escapeHtml(r.name)}</option>`)
+    .join("\n          ");
+  const rbacJson = JSON.stringify(rbac).replace(/</g, "\\u003c");
   const html = `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -475,8 +486,7 @@ function renderOSShell(): Response {
         <span id="active-app" class="active-app" aria-live="polite" aria-atomic="true">Finder</span>
         <span id="menubar-status" class="mb-status"></span>
         <select id="role-switch" class="role-switch" aria-label="Profile" title="Switch profile">
-          <option value="dj">DJ</option>
-          <option value="ka">Karl · Warehouse</option>
+          ${roleOptions}
         </select>
       </div>
       <div id="dock" class="dock" aria-label="Dock"></div>
@@ -484,6 +494,7 @@ function renderOSShell(): Response {
         <span id="clock" class="clock tnum"></span>
       </div>
     </footer>
+    <script>globalThis.THIRSTY_RBAC = ${rbacJson};</script>
     <script type="module" src="/os.js"></script>
   </body>
 </html>`;
@@ -1422,6 +1433,14 @@ export async function legacyHandler(req: Request): Promise<Response> {
         return json(listSampleStatuses());
       }
 
+      // Role-based access config (team members → capability flags). The OS shell
+      // reads the same object from `window.THIRSTY_RBAC`; this endpoint exposes
+      // it to any external consumer. Config only — per-device UX gating, not an
+      // auth boundary (see core/roles.ts).
+      if (pathname === "/api/roles") {
+        return json(rolesClientConfig());
+      }
+
       // Distinct creator handles seen in Graylog — the live attribution list for
       // the sold flow (mirrors graylog-query's `--terms creator`).
       if (pathname === "/api/creators") {
@@ -1767,6 +1786,25 @@ if (denoCron) {
       }
     } catch (e) {
       console.error("[auto-list] cron error:", e);
+    }
+  });
+
+  // Stale-checkout alerts: every 6 hours, ping DISCORD_WEBHOOK_URL about any
+  // sample stuck in `checked_out` past CHECKOUT_ALERT_HOURS (default 72h). Only
+  // the central deploy (owns the DB) runs it; a thin client no-ops. No webhook
+  // configured → the run is a no-op (see core/checkout-alerts.ts).
+  denoCron("thirsty-sample-stale-checkout", "0 */6 * * *", async () => {
+    if (REMOTE_API) return; // thin client: the central deploy owns the cron
+    try {
+      const r = await runCheckoutAlerts();
+      if (r.alerted) {
+        console.log(
+          `[checkout-alerts] alerted ${r.alerted} stale sample(s) ` +
+            `(${r.stale} over threshold, ${r.skipped} throttled)`,
+        );
+      }
+    } catch (e) {
+      console.error("[checkout-alerts] cron error:", e);
     }
   });
 } else {

--- a/static/os.js
+++ b/static/os.js
@@ -166,11 +166,14 @@ const FOLDERS = [
     id: "apps",
     name: "Apps",
     icon: ICONS.folder,
+    // RBAC: `flag` gates a folder/item per role (see globalThis.THIRSTY_RBAC).
+    flag: "folder.apps",
     items: [
       {
         id: "product-analysis",
         name: "Product Analysis",
         icon: ICONS.inventory,
+        flag: "app.productAnalysis",
         // Migrated from the kiosk — now served same-origin by data-pimp.
         url: "/inventory",
         allow: "fullscreen",
@@ -181,6 +184,7 @@ const FOLDERS = [
         id: "inventory",
         name: "Inventory",
         icon: ICONS.boxes,
+        flag: "app.inventory",
         url: "https://admin.thirsty.store",
         allow: "fullscreen; camera",
         external: true,
@@ -191,6 +195,7 @@ const FOLDERS = [
         id: "kiosk",
         name: "Kiosk",
         icon: ICONS.qr,
+        flag: "app.kiosk",
         // The storefront that used to live at thirsty.store, now an app inside
         // the OS (same-origin, served under /kiosk).
         url: "/kiosk",
@@ -202,6 +207,7 @@ const FOLDERS = [
         id: "install-extension",
         name: "Install Extension",
         icon: ICONS.boxes,
+        flag: "app.installExtension",
         // Same-origin install help: download chrome.zip + load-unpacked steps
         // (served by data-pimp at /install). Internal, so no sandbox — the
         // download link works. Opened by the samples-import skill or from Apps.
@@ -215,6 +221,7 @@ const FOLDERS = [
     id: "demos",
     name: "Demos",
     icon: ICONS.folder,
+    flag: "folder.demos",
     items: [
       {
         id: "sample-valuation",
@@ -291,6 +298,7 @@ const FOLDERS = [
     id: "member",
     name: "Member",
     icon: ICONS.folder,
+    flag: "folder.member",
     items: [
       {
         id: "tokscrape-dashboard",
@@ -322,6 +330,53 @@ const FOLDERS = [
     ],
   },
 ];
+
+/* ----------------------------------------------------------------- RBAC -- */
+
+// Per-device role gating. `globalThis.THIRSTY_RBAC` is injected by renderOSShell
+// in main.ts from core/roles.json (the single source of truth) — it maps each
+// team member (role) to capability flags. Those flags decide which folders/apps
+// this profile shows and which boot layout it gets. NOT a security boundary: the
+// OS has no auth/session, so a hidden app's same-origin URL still works if typed
+// directly. Think "kiosk profile", not server-enforced authz.
+const RBAC =
+  (globalThis.THIRSTY_RBAC && typeof globalThis.THIRSTY_RBAC === "object")
+    ? globalThis.THIRSTY_RBAC
+    : { defaultRole: "dj", roles: [], flags: [] };
+const ROLE_KEY = "thirsty-os-role";
+
+function roleById(id) {
+  return (RBAC.roles || []).find((r) => r.id === id) || null;
+}
+
+// The active role: a known stored choice, else the configured default.
+function currentRoleId() {
+  const stored = localStorage.getItem(ROLE_KEY);
+  return roleById(stored) ? stored : (RBAC.defaultRole || "dj");
+}
+
+// Explicit per-role value wins; `"*"` is the wildcard default; else deny.
+// Mirrors roleHasFlag() in core/roles.ts so browser + server agree.
+function roleAllows(roleId, flag) {
+  if (!flag) return true; // unflagged folders/items are always visible
+  const role = roleById(roleId);
+  if (!role || !role.flags) return false;
+  const explicit = role.flags[flag];
+  if (typeof explicit === "boolean") return explicit;
+  return role.flags["*"] === true;
+}
+
+const ROLE = currentRoleId();
+const allows = (flag) => roleAllows(ROLE, flag);
+
+// Folders this role may see, each trimmed to its allowed items. A folder whose
+// items are all gated away drops out entirely.
+function visibleFolders() {
+  return FOLDERS
+    .filter((f) => allows(f.flag))
+    .map((f) => ({ ...f, items: (f.items || []).filter((i) => allows(i.flag)) }))
+    .filter((f) => f.items.length > 0);
+}
 
 /* ----------------------------------------------------------- WM globals -- */
 
@@ -383,7 +438,8 @@ function makeIcon(label, svg, onOpen) {
 
 function renderDesktop() {
   const root = document.getElementById("desktop-icons");
-  for (const folder of FOLDERS) {
+  // Only the folders/apps this role may open (see RBAC above).
+  for (const folder of visibleFolders()) {
     root.appendChild(makeIcon(folder.name, folder.icon, () => openFolder(folder)));
   }
 }
@@ -1099,23 +1155,23 @@ tickClock();
 setInterval(tickClock, 15000);
 
 // Profile / role switcher. Per-device only (localStorage) — the OS has no
-// auth/session to hang a server-side role on. DJ = default; KA = warehouse Karl,
-// who boots straight into a tiled Inventory + Kiosk workspace.
-const ROLE_KEY = "thirsty-os-role";
-const role = localStorage.getItem(ROLE_KEY) || "dj";
+// auth/session to hang a server-side role on. The <option>s are rendered from
+// core/roles.json (see renderOSShell); ROLE/roleById come from the RBAC block.
 const roleSwitch = document.getElementById("role-switch");
 if (roleSwitch) {
-  roleSwitch.value = role;
+  roleSwitch.value = ROLE;
   roleSwitch.addEventListener("change", () => {
     localStorage.setItem(ROLE_KEY, roleSwitch.value);
     location.reload(); // re-run boot so the layout branch below applies cleanly
   });
 }
 
-// Warehouse boot layout: Inventory (LP Sample Tracker) tiled to the LEFT half,
-// defaulting to the "Cleared to Sell" filter; Kiosk tiled to the RIGHT half.
-// Reuses the real openApp() + snapWindow() primitives (windows keyed "app:"+id).
-if (role === "ka") {
+// Boot layout is a per-role property (roles.json `boot`). "warehouse" tiles
+// Inventory (LP Sample Tracker) to the LEFT half — defaulting to the "Cleared
+// to Sell" filter — and Kiosk to the RIGHT. Reuses the real openApp() +
+// snapWindow() primitives (windows keyed "app:"+id).
+const bootLayout = roleById(ROLE)?.boot;
+if (bootLayout === "warehouse") {
   const appsFolder = FOLDERS.find((f) => f.id === "apps");
   const apps = (appsFolder && appsFolder.items) || [];
   const inventory = apps.find((i) => i.id === "inventory");
@@ -1131,7 +1187,7 @@ if (role === "ka") {
     const w = windows.get("app:kiosk");
     if (w) snapWindow(w, "right");
   }
-  if (statusEl) statusEl.textContent = "Warehouse · Karl";
+  if (statusEl) statusEl.textContent = roleById(ROLE)?.name ?? ROLE;
 }
 
 // E2E / demo workspace: ?workspace=samples-import[&ids=...&creator=@x&autostart=1]


### PR DESCRIPTION
Implements two features for Thirsty OS / the sample tracker.

## 1. Role-based access control with configurable flags
- **`core/roles.json`** — single source of truth mapping team members (roles) → capability flags, with a `"*"` wildcard for admin.
- **`core/roles.ts`** — typed loader; `resolveFlag` (extracted, unit-testable precedence: explicit value wins, then `"*"`, else deny), `roleHasFlag`, `rolesClientConfig`.
- **`main.ts`** — `renderOSShell()` renders the profile `<select>` from config and injects `globalThis.THIRSTY_RBAC`; adds read-only `/api/roles`.
- **`static/os.js`** — gates desktop folders/apps and the boot layout by the active role's flags, mirroring the server resolver.

Adding a teammate or changing access is now a `roles.json` edit — no code change. This is **per-device UX gating** (the OS has no session), not a server-enforced auth boundary; called out in the code comments.

## 2. Deno cron alerts for items checked out too long
- **`core/checkout-alerts.ts`** — pure `findStaleCheckouts` + Discord payload builder, plus `runCheckoutAlerts` with injectable DB/cache/notifier seams.
- **`main.ts`** — `Deno.cron("thirsty-sample-stale-checkout", "0 */6 * * *")`, central-deploy only, posts to **`DISCORD_WEBHOOK_URL`**.
- **`core/lifecycle.ts`** — `recordSampleStatus` stamps `checked_out_at` on entry to `checked_out` so those rows can be aged.

Config (all optional, sane defaults): `DISCORD_WEBHOOK_URL` (unset → no-op), `CHECKOUT_ALERT_HOURS` (default 72), `CHECKOUT_ALERT_REPEAT_HOURS` (KV-backed re-alert throttle, default 24). The scan orders `checked_out_at` **ascending** so if checkouts ever exceed the 500-row cap, the stalest rows are kept — not dropped.

## Verification
- `deno check` + `deno lint` clean; `deno fmt` clean on authored files.
- **39 hermetic tests pass**, incl. 23 new (`core/roles_test.ts`, `core/checkout-alerts_test.ts`).
- RBAC gating confirmed live in-browser: DJ sees all folders; Karl sees only Apps (Product Analysis hidden), warehouse boot tiling Inventory + Kiosk.
- Went through an adversarial multi-agent review; both confirmed findings (scan truncation ordering; untested wildcard-vs-explicit-false precedence) are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)