### PR TITLE
[codex] Use live catalog products in sample E2E defaults

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1524,7 +1524,7 @@ export async function legacyHandler(req: Request): Promise<Response> {
       // page fetches it client-side. ?id=<productId> overrides the default.
       if (pathname === "/api/e2e-context") {
         if (req.method === "OPTIONS") return corsPreflight();
-        const def = (url.searchParams.get("id") || "1731301163454206492").trim();
+        const def = (url.searchParams.get("id") || "1729527400425427463").trim();
         return corsJson(await fetchE2EContext(def));
       }
 

--- a/scripts/sample-e2e.ts
+++ b/scripts/sample-e2e.ts
@@ -14,7 +14,7 @@
 //
 // Usage:
 //   deno run -A scripts/sample-e2e.ts [flags] <productId> [<productId> ...]
-//   deno task e2e:samples 1729587769570529799 9001234567890
+//   deno task e2e:samples 1729527400425427463 1729587769570529799
 //
 // Flags:
 //   --creator @handle     creator to assign to (default @e2e-test)
@@ -24,9 +24,9 @@
 //   --gelf-url URL        GELF input (or env GRAYLOG_GELF_URL) for --order-scrape
 //   --gelf-token TOKEN    GELF key   (or env GRAYLOG_TOKEN)    for --order-scrape
 //
-// If no product ids are passed, a default pair is used: one likely-priced real
-// TikTok product + one synthetic name-hash id (an "unpriced" sample), so the run
-// exercises both the priced and unpriced paths out of the box.
+// If no product ids are passed, a default pair is used from the real sample
+// catalog: one priced TikTok product + one currently-unpriced TikTok product, so
+// the run exercises both paths out of the box.
 
 type Json = Record<string, unknown>;
 
@@ -63,7 +63,7 @@ function stableProductId(name: string): string {
 
 const ids = argIds.length
   ? argIds
-  : ["1729587769570529799", stableProductId("E2E Unpriced Sample")];
+  : ["1729527400425427463", "1729587769570529799"];
 
 async function getJson(path: string): Promise<Json | Json[] | null> {
   try {


### PR DESCRIPTION
## Summary

Updates the sample lifecycle E2E defaults to use real TikTok Shop catalog product IDs instead of a synthetic name-hash sample.

## Why

The visual E2E/demo flow now relies on live catalog products and images. Matching the script/API defaults to real catalog IDs keeps the default run aligned with the demo and exercises real priced/unpriced product paths.

## Changes

- Point `/api/e2e-context` at `1729527400425427463` by default.
- Update `scripts/sample-e2e.ts` docs and fallback IDs to `1729527400425427463` and `1729587769570529799`.

## Validation

- `deno task check`

## Notes

Left local untracked `.agents/` and `.codex/` files out of this PR.